### PR TITLE
Correct Undefined repository property

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ const main = async () => {
   let finalHtml = '';
 
   const options = {
-    repository,
+    repository: repository || `${owner}/${repo}`,
     prefix: `${process.env.GITHUB_WORKSPACE}/`,
     covFile,
     xmlFile,


### PR DESCRIPTION
Relates to this issue: https://github.com/MishaKav/pytest-coverage-comment/issues/39

https://github.com/actions/toolkit/blob/d1a6612b14bbac7fdab0734324d3e2c804413663/packages/github/src/github.ts

require('@actions/github').repository is undefined

Rather take `${owner}/${repo}` 

As defined in @action/github here
https://github.com/actions/toolkit/blob/d1a6612b14bbac7fdab0734324d3e2c804413663/packages/github/src/context.ts#L6