### PR TITLE
Should not fail when runs on unsupported events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,333 @@
+# Changelog of the Pytest Coverage Comment
+
+## [Pytest Coverage Comment 1.1.37](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.37)
+
+**Release Date:** 2022-10-20
+
+#### Changes
+
+- Fix failing the action when the event type is not `pull_request`/`push`. Now it will just post `warning` message if you try to comment (and not fail the whole action). If you just using an `output` of the action you will be able to run this action on events like `schedule`/`workflow_dispatch` etc
+- Add full `CHANGELOG.md` (current file with all history). Those whos use `dependabot` now will be able to see the changes directly in the PR
+
+## [Pytest Coverage Comment 1.1.36](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.36)
+
+**Release Date:** 2022-10-12
+
+#### Changes
+
+- Upgrade `node12` to `node16`(otherwise GitHub print `warning` on that)
+
+## [Pytest Coverage Comment 1.1.35](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.35)
+
+**Release Date:** 2022-09-06
+
+#### Changes
+
+- fix empty folders on changed files (the report show empty folders even they don't contain files)
+
+## [Pytest Coverage Comment 1.1.34](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.34)
+
+**Release Date:** 2022-09-06
+
+#### Changes
+
+- fix warning when use `coverage-xml`
+
+## [Pytest Coverage Comment 1.1.33](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.33)
+
+**Release Date:** 2022-08-29
+
+#### Changes
+
+- add support for `coverage.xml`, thanks to [@xportation](https://github.com/xportation) for contribution
+
+## [Pytest Coverage Comment 1.1.32](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.32)
+
+**Release Date:** 2022-08-10
+
+#### Changes
+
+- add multi files to coverage report
+
+## [Pytest Coverage Comment 1.1.31](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.31)
+
+**Release Date:** 2022-08-09
+
+#### Changes
+
+- Add option to remove link on badge `remove-link-from-badge`
+
+## [Pytest Coverage Comment 1.1.30](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.30)
+
+**Release Date:** 2022-08-05
+
+#### Changes
+
+- fix typo, thanks to [@SimonOsipov](https://github.com/SimonOsipov) for contribution
+
+## [Pytest Coverage Comment 1.1.29](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.29)
+
+**Release Date:** 2022-06-29
+
+#### Changes
+
+- fix changed files (when the first commit comes in `push` evnet, it fails to compare it with `head` commit)
+
+## [Pytest Coverage Comment 1.1.28](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.28)
+
+**Release Date:** 2022-04-27
+
+#### Changes
+
+- Add comment to report when no files changed: <br/> _report-only-changed-files is enabled. No files were changed during this commit :)_
+
+## [Pytest Coverage Comment 1.1.27](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.27)
+
+**Release Date:** 2022-04-26
+
+#### Changes
+
+- fix parse on big files
+
+## [Pytest Coverage Comment 1.1.26](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.26)
+
+**Release Date:** 2022-04-22
+
+#### Changes
+
+- show elapsed time in minutes when it's more than 60 seconds
+- If the elapsed time is more than 1 minute, it will show it in a different format (`555.0532s` > `9m 15s`), the output format will be the same as junit.xml (`555.0532s`).
+
+## [Pytest Coverage Comment 1.1.26](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.26)
+
+**Release Date:** 2022-04-22
+
+#### Changes
+
+- Elapsed time in minutes
+
+## [Pytest Coverage Comment 1.1.25](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.25)
+
+**Release Date:** 2022-04-06
+
+#### Changes
+
+- Fix ahead of base commit
+
+## [Pytest Coverage Comment 1.1.24](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.24)
+
+**Release Date:** 2022-03-15
+
+#### Changes
+
+- Correct coverage header words to include
+
+## [Pytest Coverage Comment 1.1.23](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.23)
+
+**Release Date:** 2022-03-14
+
+#### Changes
+
+- prefix to changed files
+
+## [Pytest Coverage Comment 1.1.22](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.22)
+
+**Release Date:** 2022-03-12
+
+#### Changes
+
+- fix missing lines
+
+## [Pytest Coverage Comment 1.1.21](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.21)
+
+**Release Date:** 2022-03-10
+
+#### Changes
+
+- add links in comment with prefix
+
+## [Pytest Coverage Comment 1.1.20](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.20)
+
+**Release Date:** 2022-03-08
+
+#### Changes
+
+- fix cover td
+
+## [Pytest Coverage Comment 1.1.19](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.19)
+
+**Release Date:** 2022-02-24
+
+#### Changes
+
+- fix cover export with old syntax
+
+## [Pytest Coverage Comment 1.1.18](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.18)
+
+**Release Date:** 2022-02-24
+
+#### Changes
+
+- fix cover percentage when using `cov-branch`
+
+## [Pytest Coverage Comment 1.1.17](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.17)
+
+**Release Date:** 2022-01-21
+
+#### Changes
+
+- add option to `reportOnlyChangedFiles`
+
+## [Pytest Coverage Comment 1.1.16](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.16)
+
+**Release Date:** 2021-12-09
+
+#### Changes
+
+- fix table when missing column are not there
+
+## [Pytest Coverage Comment 1.1.15](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.15)
+
+**Release Date:** 2021-12-09
+
+#### Changes
+
+- fix repository name when `undefined` \
+  Thanks to [@OTooleMichael](https://github.com/OTooleMichael) for contribution
+
+## [Pytest Coverage Comment 1.1.14](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.14)
+
+**Release Date:** 2021-12-04
+
+#### Changes
+
+- fix repository name when run on `schedule`
+
+## [Pytest Coverage Comment 1.1.13](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.13)
+
+**Release Date:** 2021-12-01
+
+#### Changes
+
+- fix parsing issues in some cases
+
+## [Pytest Coverage Comment 1.1.12](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.12)
+
+**Release Date:** 2021-11-11
+
+#### Changes
+
+- Add summary report to output to multiFiles
+
+## [Pytest Coverage Comment 1.1.11](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.11)
+
+**Release Date:** 2021-10-31
+
+#### Changes
+
+- add warnings to output
+
+## [Pytest Coverage Comment 1.1.10](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.10)
+
+**Release Date:** 2021-10-16
+
+#### Changes
+
+- fork for notSuccessTestInfo
+
+## [Pytest Coverage Comment 1.1.9](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.9)
+
+**Release Date:** 2021-09-08
+
+#### Changes
+
+- add values from to output variables
+
+## [Pytest Coverage Comment 1.1.8](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.8)
+
+**Release Date:** 2021-09-08
+
+#### Changes
+
+- add `coverageHtml` to multiFiles mode
+
+## [Pytest Coverage Comment 1.1.7](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.7)
+
+**Release Date:** 2021-09-08
+
+#### Changes
+
+- Export coverage example
+
+## [Pytest Coverage Comment 1.1.6](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.6)
+
+**Release Date:** 2021-07-26
+
+#### Changes
+
+- Add option to hide the comment (will generate only the `output`)
+
+## [Pytest Coverage Comment 1.1.5](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.5)
+
+**Release Date:** 2021-07-17
+
+#### Changes
+
+- fix error body to long
+
+## [Pytest Coverage Comment 1.1.4](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.4)
+
+**Release Date:** 2021-07-13
+
+#### Changes
+
+- add output for first file when multiple files mode enabled
+
+## [Pytest Coverage Comment 1.1.3](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.3)
+
+**Release Date:** 2021-06-24
+
+#### Changes
+
+- fix validation of a coverage file
+
+## [Pytest Coverage Comment 1.1.2](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.2)
+
+**Release Date:** 2021-06-23
+
+#### Changes
+
+- add check if coverage file is valid
+
+## [Pytest Coverage Comment 1.1.1](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.1)
+
+**Release Date:** 2021-06-19
+
+#### Changes
+
+- ignore files that didn't exists in multi-mode
+
+## [Pytest Coverage Comment 1.1.0](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.0)
+
+**Release Date:** 2021-06-15
+
+#### Changes
+
+- Multiple Files Mode (can be useful on mono-repo projects)
+  ![Result Multiple Files Mode Example](https://user-images.githubusercontent.com/289035/122121939-ddd0c500-ce34-11eb-8546-89a8a769e065.png)
+
+## [Pytest Coverage Comment 1.0.1](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.0.1)
+
+**Release Date:** 2021-06-15
+
+#### Changes
+
+- improove watermark
+
+## [Pytest Coverage Comment 1.0](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.0)
+
+**Release Date:** 2021-06-02
+
+#### Changes
+
+- Initial publication on GitHub. The first release of the action.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,20 +9,20 @@
       "version": "1.1.36",
       "license": "MIT",
       "dependencies": {
-        "@actions/core": "^1.9.1",
+        "@actions/core": "^1.10.0",
         "@actions/github": "^4.0.0",
         "xml2js": "^0.4.23"
       },
       "devDependencies": {
         "@vercel/ncc": "^0.34.0",
-        "eslint": "^8.21.0",
+        "eslint": "^8.25.0",
         "prettier": "^2.7.1"
       }
     },
     "node_modules/@actions/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-5ad+U2YGrmmiw6du20AQW5XuWo7UKN2052FjSV7MX+Wfjf8sCqcsZe62NfgHys4QI4/Y+vQvLKYL8jWtA1ZBTA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
       "dependencies": {
         "@actions/http-client": "^2.0.1",
         "uuid": "^8.3.2"
@@ -57,14 +57,14 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
-      "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
+      "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.3.2",
+        "espree": "^9.4.0",
         "globals": "^13.15.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
@@ -74,12 +74,15 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.4.tgz",
-      "integrity": "sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==",
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.7.tgz",
+      "integrity": "sha512-MDl6D6sBsaV452/QSdX+4CXIjZhIcI0PELsxUjk4U828yd58vk3bTIvk/6w5FY+4hIy9sLW0sfrV7K7Kc++j/w==",
       "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -90,11 +93,14 @@
         "node": ">=10.10.0"
       }
     },
-    "node_modules/@humanwhocodes/gitignore-to-minimatch": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
-      "integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
+      "engines": {
+        "node": ">=12.22"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
@@ -455,9 +461,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -507,14 +513,14 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.21.0.tgz",
-      "integrity": "sha512-/XJ1+Qurf1T9G2M5IHrsjp+xrGT73RZf23xA1z5wB1ZzzEAWSZKvRwhWxTFp1rvkvCfwcvAUNAP31bhKTTGfDA==",
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.25.0.tgz",
+      "integrity": "sha512-DVlJOZ4Pn50zcKW5bYH7GQK/9MsoQG2d5eDH0ebEkE8PbgzTTmtt/VTH9GGJ4BfeZCpBLqFfvsjX35UacUL83A==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.3.0",
-        "@humanwhocodes/config-array": "^0.10.4",
-        "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
+        "@eslint/eslintrc": "^1.3.3",
+        "@humanwhocodes/config-array": "^0.10.5",
+        "@humanwhocodes/module-importer": "^1.0.1",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -524,13 +530,12 @@
         "eslint-scope": "^7.1.1",
         "eslint-utils": "^3.0.0",
         "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.3.3",
+        "espree": "^9.4.0",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "find-up": "^5.0.0",
-        "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
         "globals": "^13.15.0",
         "globby": "^11.1.0",
@@ -539,6 +544,7 @@
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
+        "js-sdsl": "^4.1.4",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
@@ -549,8 +555,7 @@
         "regexpp": "^3.2.0",
         "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
-        "text-table": "^0.2.0",
-        "v8-compile-cache": "^2.0.3"
+        "text-table": "^0.2.0"
       },
       "bin": {
         "eslint": "bin/eslint.js"
@@ -624,9 +629,9 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.3.tgz",
-      "integrity": "sha512-ORs1Rt/uQTqUKjDdGCyrtYxbazf5umATSf/K4qxjmZHORR6HJk+2s/2Pqe+Kk49HHINC/xNIrGfgh8sZcll0ng==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.0.tgz",
+      "integrity": "sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.8.0",
@@ -802,12 +807,6 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "node_modules/functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-      "dev": true
-    },
     "node_modules/glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -838,9 +837,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.15.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
-      "integrity": "sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==",
+      "version": "13.17.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
+      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -962,6 +961,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "node_modules/js-sdsl": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
+      "integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
       "dev": true
     },
     "node_modules/js-yaml": {
@@ -1457,12 +1462,6 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/v8-compile-cache": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
-      "dev": true
-    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -1541,9 +1540,9 @@
   },
   "dependencies": {
     "@actions/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-5ad+U2YGrmmiw6du20AQW5XuWo7UKN2052FjSV7MX+Wfjf8sCqcsZe62NfgHys4QI4/Y+vQvLKYL8jWtA1ZBTA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
       "requires": {
         "@actions/http-client": "^2.0.1",
         "uuid": "^8.3.2"
@@ -1579,14 +1578,14 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
-      "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
+      "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.3.2",
+        "espree": "^9.4.0",
         "globals": "^13.15.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
@@ -1596,9 +1595,9 @@
       }
     },
     "@humanwhocodes/config-array": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.4.tgz",
-      "integrity": "sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==",
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.7.tgz",
+      "integrity": "sha512-MDl6D6sBsaV452/QSdX+4CXIjZhIcI0PELsxUjk4U828yd58vk3bTIvk/6w5FY+4hIy9sLW0sfrV7K7Kc++j/w==",
       "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -1606,10 +1605,10 @@
         "minimatch": "^3.0.4"
       }
     },
-    "@humanwhocodes/gitignore-to-minimatch": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
-      "integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
+    "@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true
     },
     "@humanwhocodes/object-schema": {
@@ -1907,9 +1906,9 @@
       }
     },
     "debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "requires": {
         "ms": "2.1.2"
@@ -1945,14 +1944,14 @@
       }
     },
     "eslint": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.21.0.tgz",
-      "integrity": "sha512-/XJ1+Qurf1T9G2M5IHrsjp+xrGT73RZf23xA1z5wB1ZzzEAWSZKvRwhWxTFp1rvkvCfwcvAUNAP31bhKTTGfDA==",
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.25.0.tgz",
+      "integrity": "sha512-DVlJOZ4Pn50zcKW5bYH7GQK/9MsoQG2d5eDH0ebEkE8PbgzTTmtt/VTH9GGJ4BfeZCpBLqFfvsjX35UacUL83A==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.3.0",
-        "@humanwhocodes/config-array": "^0.10.4",
-        "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
+        "@eslint/eslintrc": "^1.3.3",
+        "@humanwhocodes/config-array": "^0.10.5",
+        "@humanwhocodes/module-importer": "^1.0.1",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -1962,13 +1961,12 @@
         "eslint-scope": "^7.1.1",
         "eslint-utils": "^3.0.0",
         "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.3.3",
+        "espree": "^9.4.0",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "find-up": "^5.0.0",
-        "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
         "globals": "^13.15.0",
         "globby": "^11.1.0",
@@ -1977,6 +1975,7 @@
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
+        "js-sdsl": "^4.1.4",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
@@ -1987,8 +1986,7 @@
         "regexpp": "^3.2.0",
         "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
-        "text-table": "^0.2.0",
-        "v8-compile-cache": "^2.0.3"
+        "text-table": "^0.2.0"
       },
       "dependencies": {
         "escape-string-regexp": {
@@ -2033,9 +2031,9 @@
       "dev": true
     },
     "espree": {
-      "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.3.tgz",
-      "integrity": "sha512-ORs1Rt/uQTqUKjDdGCyrtYxbazf5umATSf/K4qxjmZHORR6HJk+2s/2Pqe+Kk49HHINC/xNIrGfgh8sZcll0ng==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.0.tgz",
+      "integrity": "sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==",
       "dev": true,
       "requires": {
         "acorn": "^8.8.0",
@@ -2174,12 +2172,6 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-      "dev": true
-    },
     "glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -2204,9 +2196,9 @@
       }
     },
     "globals": {
-      "version": "13.15.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
-      "integrity": "sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==",
+      "version": "13.17.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
+      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
@@ -2295,6 +2287,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "js-sdsl": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
+      "integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
       "dev": true
     },
     "js-yaml": {
@@ -2626,12 +2624,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-    },
-    "v8-compile-cache": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
-      "dev": true
     },
     "webidl-conversions": {
       "version": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pytest-coverage-comment",
-  "version": "1.1.36",
+  "version": "1.1.37",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pytest-coverage-comment",
-      "version": "1.1.36",
+      "version": "1.1.37",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
     "all": "npm run lint && npm run format && npm run build"
   },
   "dependencies": {
-    "@actions/core": "^1.9.1",
+    "@actions/core": "^1.10.0",
     "@actions/github": "^4.0.0",
     "xml2js": "^0.4.23"
   },
   "devDependencies": {
     "@vercel/ncc": "^0.34.0",
-    "eslint": "^8.21.0",
+    "eslint": "^8.25.0",
     "prettier": "^2.7.1"
   },
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pytest-coverage-comment",
-  "version": "1.1.36",
+  "version": "1.1.37",
   "description": "Comments a pull request with the pytest code coverage badge, full report and tests summary",
   "author": "Misha Kav",
   "license": "MIT",

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+const { mkdirSync, writeFileSync } = require('fs');
 const path = require('path');
 const { getCoverageReport } = require('./parse');
 const {
@@ -115,9 +115,9 @@ const main = async () => {
     return;
   }
 
-  const resultFile = __dirname + '/../tmp/result.md';
-  fs.promises.mkdir(__dirname + '/../tmp').catch(console.error);
-  fs.writeFileSync(resultFile, finalHtml);
+  const resultFile = `${__dirname}/../tmp/result.md`;
+  mkdirSync(`${__dirname}/../tmp`, { recursive: true });
+  writeFileSync(resultFile, finalHtml);
   console.log(resultFile);
 };
 


### PR DESCRIPTION
- Fix failing the action when the event type is not `pull_request`/`push`. Now it will just post `warning` message if you try to comment (and not fail the whole action). If you just using an `output` of the action you will be able to run this action on events like `schedule`/`workflow_dispatch` etc
- Add full `CHANGELOG.md` (current file with all history). Those whos use `dependabot` now will be able to see the changes directly in the PR