### PR TITLE
Fix support for multiple-files without pytest reports

### DIFF
--- a/.github/workflows/multiple-files.yml
+++ b/.github/workflows/multiple-files.yml
@@ -13,3 +13,27 @@ jobs:
           multiple-files: |
             My Title 1, ./data/pytest-coverage_3.txt, ./data/pytest_1.xml
             My Title 2, ./data/pytest-coverage_4.txt, ./data/pytest_2.xml
+
+      - name: Pytest coverage comment multiple-files no test report
+        uses: MishaKav/pytest-coverage-comment@main
+        with:
+          create-new-comment: true
+          multiple-files: |
+            My Title 1 w/o report, ./data/pytest-coverage_3.txt
+            My Title 2 w/o report, ./data/pytest-coverage_4.txt
+
+      - name: Pytest coverage comment multiple-files mixed 1
+        uses: MishaKav/pytest-coverage-comment@main
+        with:
+          create-new-comment: true
+          multiple-files: |
+            My Title 1 w/ report, ./data/pytest-coverage_3.txt, ./data/pytest_1.xml
+            My Title 2 w/o report, ./data/pytest-coverage_4.txt
+
+      - name: Pytest coverage comment multiple-files mixed 2
+        uses: MishaKav/pytest-coverage-comment@main
+        with:
+          create-new-comment: true
+          multiple-files: |
+            My Title 1 w/o report, ./data/pytest-coverage_3.txt
+            My Title 2 w/ report, ./data/pytest-coverage_4.txt, ./data/pytest_2.xml

--- a/dist/index.js
+++ b/dist/index.js
@@ -16898,7 +16898,7 @@ const getMultipleReport = (options) => {
     const lineReports = multipleFiles.map(parseLine).filter((l) => l);
     const hasXmlReports = lineReports.some((l) => l.xmlFile);
     const miniTable = `| Title | Coverage |
-| ----- | ----- | ----- |
+| ----- | ----- |
 `;
     const fullTable = `| Title | Coverage | Tests | Skipped | Failures | Errors | Time |
 | ----- | ----- | ----- | ------- | -------- | -------- | ------------------ |

--- a/dist/index.js
+++ b/dist/index.js
@@ -16876,7 +16876,7 @@ const parseLine = (line) => {
   return {
     title: lineArr[0].trim(),
     covFile: lineArr[1].trim(),
-    xmlFile: lineArr.length > 1 ? lineArr[2].trim() : '',
+    xmlFile: lineArr.length > 2 ? lineArr[2].trim() : '',
   };
 };
 

--- a/src/multiFiles.js
+++ b/src/multiFiles.js
@@ -13,7 +13,7 @@ const parseLine = (line) => {
   return {
     title: lineArr[0].trim(),
     covFile: lineArr[1].trim(),
-    xmlFile: lineArr.length > 1 ? lineArr[2].trim() : '',
+    xmlFile: lineArr.length > 2 ? lineArr[2].trim() : '',
   };
 };
 

--- a/src/multiFiles.js
+++ b/src/multiFiles.js
@@ -35,7 +35,7 @@ const getMultipleReport = (options) => {
     const lineReports = multipleFiles.map(parseLine).filter((l) => l);
     const hasXmlReports = lineReports.some((l) => l.xmlFile);
     const miniTable = `| Title | Coverage |
-| ----- | ----- | ----- |
+| ----- | ----- |
 `;
     const fullTable = `| Title | Coverage | Tests | Skipped | Failures | Errors | Time |
 | ----- | ----- | ----- | ------- | -------- | -------- | ------------------ |


### PR DESCRIPTION
Thanks for this action, it's really useful :) 

I noticed that without a third item in the multiple-files row, the action fails on trim. If you leave the field blank after a comma it will continue but the table is not formatted correctly because of the column count mismatch.

This PR fixes those two issues and adds some checks in the multiple-files workflow for it. You can see some examples here
https://github.com/jbcumming/pytest-coverage-comment/pull/5

Let me know if it needs any changes, thanks!