### PR TITLE
feat: use context repo html_url as base for links if available

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -17168,7 +17168,7 @@ const toHtml = (data, options, dataFromXml = null) => {
   const total = dataFromXml ? dataFromXml.total : getTotal(data);
   const color = getCoverageColor(total.cover);
   const onlyChnaged = reportOnlyChangedFiles ? '• ' : '';
-  const readmeHref = `https://github.com/${options.repository}/blob/${options.commit}/README.md`;
+  const readmeHref = `${options.repoUrl}/blob/${options.commit}/README.md`;
   const badge = `<img alt="${badgeTitle}" src="https://img.shields.io/badge/${badgeTitle}-${total.cover}25-${color}.svg" />`;
   const badgeWithLink = removeLinkFromBadge
     ? badge
@@ -17266,7 +17266,7 @@ const toTotalRow = (item, options) => {
 // make fileName cell - td
 const toFileNameTd = (item, indent = false, options) => {
   const relative = item.name.replace(options.prefix, '');
-  const href = `https://github.com/${options.repository}/blob/${options.commit}/${options.pathPrefix}${relative}`;
+  const href = `${options.repoUrl}/blob/${options.commit}/${options.pathPrefix}${relative}`;
   const parts = relative.split('/');
   const last = parts[parts.length - 1];
   const space = indent ? '&nbsp; &nbsp;' : '';
@@ -17295,7 +17295,7 @@ const toMissingTd = (item, options) => {
       const [start, end = start] = range.split('-');
       const fragment = start === end ? `L${start}` : `L${start}-L${end}`;
       const relative = item.name;
-      const href = `https://github.com/${options.repository}/blob/${options.commit}/${options.pathPrefix}${relative}#${fragment}`;
+      const href = `${options.repoUrl}/blob/${options.commit}/${options.pathPrefix}${relative}#${fragment}`;
       const text = start === end ? start : `${start}&ndash;${end}`;
 
       return `<a href="${href}">${text}</a>`;
@@ -17866,6 +17866,8 @@ const main = async () => {
     xmlTitle,
     multipleFiles,
   };
+  options.repoUrl =
+    payload.repository?.html_url || `https://github.com/${options.repository}`;
 
   if (eventName === 'pull_request') {
     options.commit = payload.pull_request.head.sha;

--- a/src/index.js
+++ b/src/index.js
@@ -77,6 +77,8 @@ const main = async () => {
     xmlTitle,
     multipleFiles,
   };
+  options.repoUrl =
+    payload.repository?.html_url || `https://github.com/${options.repository}`;
 
   if (eventName === 'pull_request') {
     options.commit = payload.pull_request.head.sha;

--- a/src/parse.js
+++ b/src/parse.js
@@ -194,7 +194,7 @@ const toHtml = (data, options, dataFromXml = null) => {
   const total = dataFromXml ? dataFromXml.total : getTotal(data);
   const color = getCoverageColor(total.cover);
   const onlyChnaged = reportOnlyChangedFiles ? '• ' : '';
-  const readmeHref = `https://github.com/${options.repository}/blob/${options.commit}/README.md`;
+  const readmeHref = `${options.repoUrl}/blob/${options.commit}/README.md`;
   const badge = `<img alt="${badgeTitle}" src="https://img.shields.io/badge/${badgeTitle}-${total.cover}25-${color}.svg" />`;
   const badgeWithLink = removeLinkFromBadge
     ? badge
@@ -292,7 +292,7 @@ const toTotalRow = (item, options) => {
 // make fileName cell - td
 const toFileNameTd = (item, indent = false, options) => {
   const relative = item.name.replace(options.prefix, '');
-  const href = `https://github.com/${options.repository}/blob/${options.commit}/${options.pathPrefix}${relative}`;
+  const href = `${options.repoUrl}/blob/${options.commit}/${options.pathPrefix}${relative}`;
   const parts = relative.split('/');
   const last = parts[parts.length - 1];
   const space = indent ? '&nbsp; &nbsp;' : '';
@@ -321,7 +321,7 @@ const toMissingTd = (item, options) => {
       const [start, end = start] = range.split('-');
       const fragment = start === end ? `L${start}` : `L${start}-L${end}`;
       const relative = item.name;
-      const href = `https://github.com/${options.repository}/blob/${options.commit}/${options.pathPrefix}${relative}#${fragment}`;
+      const href = `${options.repoUrl}/blob/${options.commit}/${options.pathPrefix}${relative}#${fragment}`;
       const text = start === end ? start : `${start}&ndash;${end}`;
 
       return `<a href="${href}">${text}</a>`;


### PR DESCRIPTION
Using this action in a github enterprise repo with a different github URL means the links try and resolve against github.com and are not found. 

repoUrl is one of the options returns by github and matches the `https://github.com/${options.repository}` currently referenced but with the correct server address.