### PR TITLE
fix: increase stmts counters when using coverage.xml

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -10,7 +10,7 @@ const { getMultipleReport } = require('./multiFiles');
 const { getCoverageXmlReport } = require('./parseXml');
 
 /*  
-  Usefull git commands
+  Useful git commands
   git tag -a -m "Export coverage example" v1.1.7 && git push --follow-tags 
   git tag -d v1.0 
   git tag -d origin v1.0  
@@ -29,7 +29,7 @@ const getPathToFile = (pathToFile) => {
     return null;
   }
 
-  // suports absolute path like '/tmp/pytest-coverage.txt'
+  // supports absolute path like '/tmp/pytest-coverage.txt'
   return pathToFile.startsWith('/') ? pathToFile : `${__dirname}/${pathToFile}`;
 };
 

--- a/src/parse.js
+++ b/src/parse.js
@@ -1,7 +1,7 @@
 const core = require('@actions/core');
 const { getPathToFile, getContentFile, getCoverageColor } = require('./utils');
 
-// return true if "covergae file" include all special words
+// return true if "coverage file" include all special words
 const isValidCoverageContent = (data) => {
   if (!data || !data.length) {
     return false;
@@ -18,7 +18,7 @@ const isValidCoverageContent = (data) => {
   return wordsToInclude.every((w) => data.includes(w));
 };
 
-// return full html coverage report and coverage percenatge
+// return full html coverage report and coverage percentage
 const getCoverageReport = (options) => {
   const { covFile, covXmlFile } = options;
 
@@ -116,7 +116,7 @@ const parseOneLine = (line) => {
   const missing = isFullCoverage
     ? null
     : parsedLine[parsedLine.length - 1] &&
-      parsedLine[parsedLine.length - 1].split(', ');
+    parsedLine[parsedLine.length - 1].split(', ');
 
   return {
     name: parsedLine[0],

--- a/src/parseXml.js
+++ b/src/parseXml.js
@@ -32,7 +32,7 @@ const getTotalCoverage = (parsedXml) => {
   };
 };
 
-// return true if "covergae file" include right structure
+// return true if "coverage file" include right structure
 const isValidCoverageContent = (parsedXml) => {
   if (!parsedXml || !parsedXml.packages || !parsedXml.packages.length) {
     return false;
@@ -142,10 +142,11 @@ const parseLines = (lines) => {
     return { stmts: '0', missing: '', totalMissing: '0' };
   }
 
-  let stmts = '0';
+  let stmts = 0;
   const missingLines = [];
 
   lines[0].line.forEach((line) => {
+    stmts++;
     const { hits, number } = line['$'];
 
     if (hits === '0') {

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,7 +6,7 @@ const getPathToFile = (pathToFile) => {
     return null;
   }
 
-  // suports absolute path like '/tmp/pytest-coverage.txt'
+  // supports absolute path like '/tmp/pytest-coverage.txt'
   return pathToFile.startsWith('/')
     ? pathToFile
     : `${process.env.GITHUB_WORKSPACE}/${pathToFile}`;


### PR DESCRIPTION
I noticed the `stmts` counters are always `0` at the file level in the coverage report when reading coverage data from `coverage.xml`. The culprit seems to be the `stmts` variable, which is never incremented in `parseXml.js`/`parseLines()`. 

This PR proposes a fix to the issue. The updated results are highlighted below:

<img width="1178" alt="Screenshot 2023-01-23 at 13 35 53" src="https://user-images.githubusercontent.com/30279287/214100465-37e83ef8-825f-4957-a9c4-18c5e3646bcd.png">

Additionally, I've fixed some typos in the comments on other files. 

Closes #108.