### PR TITLE
Fix generating coverage when all files `skip-covered`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog of the Pytest Coverage Comment
 
+## [Pytest Coverage Comment 1.1.47](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.47)
+
+**Release Date:** 2023-03-18
+
+#### Changes
+
+- Fix generating coverage report when all files `skip-covered`
+
 ## [Pytest Coverage Comment 1.1.46](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.46)
 
 **Release Date:** 2023-03-03

--- a/data/pytest-coverage_12.txt
+++ b/data/pytest-coverage_12.txt
@@ -1,0 +1,11 @@
+============================= test session starts ==============================
+platform linux -- Python 3.8.12, pytest-6.2.3, py-1.11.0, pluggy-0.13.1
+
+---------- coverage: platform darwin, python 3.10.6-final-0 ----------
+Name    Stmts   Miss  Cover   Missing
+-------------------------------------
+-------------------------------------
+TOTAL    2922      0   100%
+
+86 files skipped due to complete coverage.
+Coverage XML written to file coverage.xml

--- a/dist/index.js
+++ b/dist/index.js
@@ -17047,7 +17047,7 @@ const getTotal = (data) => {
   }
 
   const lines = data.split('\n');
-  const line = lines.find((l) => l.includes('TOTAL     '));
+  const line = lines.find((l) => l.includes('TOTAL    '));
 
   return parseTotalLine(line);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pytest-coverage-comment",
-  "version": "1.1.46",
+  "version": "1.1.47",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pytest-coverage-comment",
-      "version": "1.1.46",
+      "version": "1.1.47",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pytest-coverage-comment",
-  "version": "1.1.46",
+  "version": "1.1.47",
   "description": "Comments a pull request with the pytest code coverage badge, full report and tests summary",
   "author": "Misha Kav",
   "license": "MIT",

--- a/src/parse.js
+++ b/src/parse.js
@@ -73,7 +73,7 @@ const getTotal = (data) => {
   }
 
   const lines = data.split('\n');
-  const line = lines.find((l) => l.includes('TOTAL     '));
+  const line = lines.find((l) => l.includes('TOTAL    '));
 
   return parseTotalLine(line);
 };


### PR DESCRIPTION
- Fix generating coverage report when all files `skip-covered`