### PR TITLE
Fix commit SHA for workflow_run

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -17928,12 +17928,14 @@ const main = async () => {
   } else if (eventName === 'push') {
     options.commit = payload.after;
     options.head = context.ref;
-  } else if (
-    eventName === 'workflow_dispatch' ||
-    eventName === 'workflow_run'
-  ) {
+  } else if (eventName === 'workflow_dispatch') {
     options.commit = context.sha;
     options.head = context.ref;
+  } else if (eventName === 'workflow_run') {
+    options.commit =
+      payload.workflow_run.pull_requests[0]?.head.sha ?? context.sha;
+    options.head =
+      payload.workflow_run.pull_requests[0]?.head.ref ?? context.ref;
   }
 
   if (options.reportOnlyChangedFiles) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -17932,10 +17932,8 @@ const main = async () => {
     options.commit = context.sha;
     options.head = context.ref;
   } else if (eventName === 'workflow_run') {
-    options.commit =
-      payload.workflow_run.pull_requests[0]?.head.sha ?? context.sha;
-    options.head =
-      payload.workflow_run.pull_requests[0]?.head.ref ?? context.ref;
+    options.commit = payload.workflow_run.head_sha;
+    options.head = payload.workflow_run.head_branch;
   }
 
   if (options.reportOnlyChangedFiles) {

--- a/src/index.js
+++ b/src/index.js
@@ -129,10 +129,8 @@ const main = async () => {
     options.commit = context.sha;
     options.head = context.ref;
   } else if (eventName === 'workflow_run') {
-    options.commit =
-      payload.workflow_run.pull_requests[0]?.head.sha ?? context.sha;
-    options.head =
-      payload.workflow_run.pull_requests[0]?.head.ref ?? context.ref;
+    options.commit = payload.workflow_run.head_sha;
+    options.head = payload.workflow_run.head_branch;
   }
 
   if (options.reportOnlyChangedFiles) {

--- a/src/index.js
+++ b/src/index.js
@@ -125,12 +125,14 @@ const main = async () => {
   } else if (eventName === 'push') {
     options.commit = payload.after;
     options.head = context.ref;
-  } else if (
-    eventName === 'workflow_dispatch' ||
-    eventName === 'workflow_run'
-  ) {
+  } else if (eventName === 'workflow_dispatch') {
     options.commit = context.sha;
     options.head = context.ref;
+  } else if (eventName === 'workflow_run') {
+    options.commit =
+      payload.workflow_run.pull_requests[0]?.head.sha ?? context.sha;
+    options.head =
+      payload.workflow_run.pull_requests[0]?.head.ref ?? context.ref;
   }
 
   if (options.reportOnlyChangedFiles) {


### PR DESCRIPTION
This PR should close #157, by using the commit SHA and ref from the pull request when using `workflow_run`, instead of from the default branch.