### PR TITLE
Use `label` instead of `ref` for workflow_run and workflow_dispatch

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -18136,8 +18136,8 @@ const getChangedFiles = async (options, pr_number) => {
           pull_number: pr_number,
         });
 
-        base = data.base.ref;
-        head = data.head.ref;
+        base = data.base.label;
+        head = data.head.label;
         break;
       }
       default:

--- a/src/index.js
+++ b/src/index.js
@@ -333,8 +333,8 @@ const getChangedFiles = async (options, pr_number) => {
           pull_number: pr_number,
         });
 
-        base = data.base.ref;
-        head = data.head.ref;
+        base = data.base.label;
+        head = data.head.label;
         break;
       }
       default:


### PR DESCRIPTION
Closes #159 

Use `label` instead of `ref` when fetching the base and head for comparing commits. This includes the repo owner, e.g. `MishaKav:main` instead of just the branch name, so it works with forks. It also works for non-forks.