### PR TITLE
Fix typo s/Percantage/Percentage/

### DIFF
--- a/.github/workflows/live-test.yml
+++ b/.github/workflows/live-test.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Check the output coverage
         run: |
-          echo "Coverage Percantage - ${{ steps.coverageComment.outputs.coverage }}"
+          echo "Coverage Percentage - ${{ steps.coverageComment.outputs.coverage }}"
           echo "Coverage Color - ${{ steps.coverageComment.outputs.color }}"
           echo "Coverage Html - ${{ steps.coverageComment.outputs.coverageHtml }}"
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Example GitHub Action workflow that uses coverage percentage as output (see the 
 
 - name: Check the output coverage
   run: |
-    echo "Coverage Percantage - ${{ steps.coverageComment.outputs.coverage }}"
+    echo "Coverage Percentage - ${{ steps.coverageComment.outputs.coverage }}"
     echo "Coverage Color - ${{ steps.coverageComment.outputs.color }}"
     echo "Coverage Html - ${{ steps.coverageComment.outputs.coverageHtml }}"
     echo "Summary Report - ${{ steps.coverageComment.outputs.summaryReport }}"


### PR DESCRIPTION
Fixes typo by changing all instances of `Percantage` with `Percentage`.