### PR TITLE
Add test failure/errors details as collapsible

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -4,7 +4,6 @@ const { getCoverageReport } = require('./parse');
 const {
   getSummaryReport,
   getParsedXml,
-  getNotSuccessTest,
 } = require('./junitXml');
 const { getMultipleReport } = require('./multiFiles');
 const { getCoverageXmlReport } = require('./parseXml');
@@ -90,7 +89,7 @@ const main = async () => {
     const parsedXml = getParsedXml(options);
     const { errors, failures, skipped, tests, time } = parsedXml;
     const valuesToExport = { errors, failures, skipped, tests, time };
-    const notSuccessTestInfo = getNotSuccessTest(options);
+    const notSuccessTestInfo = parsedXml.notSuccessTestInfo;
 
     console.log('notSuccessTestInfo', JSON.stringify(notSuccessTestInfo));
 

--- a/src/junitXml.js
+++ b/src/junitXml.js
@@ -80,7 +80,12 @@ const getNotSuccessTest = (data) => {
     if (data) {
       const testCaseToOutput = (testcase) => {
         const { classname, name } = testcase['$'];
-        return { classname, name };
+        const failure = testcase.failure ? testcase.failure[0] : null;
+        const error = testcase.error ? testcase.error[0] : null;
+        const skipped = testcase.skipped ? testcase.skipped[0] : null;
+        const message = failure ? failure['_'] : error ? error['_'] : skipped ? skipped['_'] : null;
+
+        return { classname, name, failure, error, skipped, message };
       };
 
       const testcases = getTestCases(data);


### PR DESCRIPTION
This PR aims to add the details of the failed/skipped/error test as a collapsible, similar to what is done for the details of the coverage.

Collapsed:
![Screenshot 2025-02-10 at 16 41 07](https://github.com/user-attachments/assets/fe92fa73-1143-4e86-af48-aa4ec03e0034)

Expanded:
![Screenshot 2025-02-10 at 16 40 49](https://github.com/user-attachments/assets/90cd6fb6-4f71-46a9-b571-eb7cba8fe3a6)

This PRs includes a very small refactoring so that `getNotSuccessTest` is only called once, and passed on with the summary details.