### PR TITLE
Remove redundant call to getCoverageReport to fix the coverageHtml ou…

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -18686,9 +18686,7 @@ const main = async () => {
   }
 
   if (html) {
-    const newOptions = { ...options, commit: defaultBranch };
-    const output = getCoverageReport(newOptions);
-    core.setOutput('coverageHtml', output.html);
+    core.setOutput('coverageHtml', html);
   }
 
   // set to output junitxml values

--- a/src/index.js
+++ b/src/index.js
@@ -158,9 +158,7 @@ const main = async () => {
   }
 
   if (html) {
-    const newOptions = { ...options, commit: defaultBranch };
-    const output = getCoverageReport(newOptions);
-    core.setOutput('coverageHtml', output.html);
+    core.setOutput('coverageHtml', html);
   }
 
   // set to output junitxml values


### PR DESCRIPTION
Fixes the Issue #204 

The issue was due to the following code block.

```js
  if (html) {
    const newOptions = { ...options, commit: defaultBranch };
    const output = getCoverageReport(newOptions);
    core.setOutput('coverageHtml', output.html);
  }
  ```
The `getCoverageReport` always returns empty string if the covfile is `covXmlFile`. 

```js
// return full html coverage report and coverage percentage
const getCoverageReport = (options) => {
  const { covFile, covXmlFile } = options;

  if (!covXmlFile) {
    ...
  }

  return { html: '', coverage: '0', color: 'red', warnings: 0 };
};
```

So the line `const output = getCoverageReport(newOptions);` sets the `output.html` to empty string.

I removed this line altogether because it seems redundant when you look a few lines above.  

```js
  let report = options.covXmlFile
    ? getCoverageXmlReport(options)
    : getCoverageReport(options);
  const { coverage, color, html, warnings } = report;
  const summaryReport = getSummaryReport(options);
  ```
  
  This already calls the correct version of `getCoverageReport`. So calling it again seems kinda redundant. Unless I am missing some obscure corner case for which the line  `const output = getCoverageReport(newOptions);` was added. 

