### PR TITLE
truncate step summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog of the Pytest Coverage Comment
 
+## [Pytest Coverage Comment 1.1.55](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.55)
+
+**Release Date:** 2025-08-09
+
+#### Changes
+
+- fix GitHub Action Summary size limit error by implementing automatic truncation for summaries exceeding 1MB (#209)
+- bump dev dependencies
+
 ## [Pytest Coverage Comment 1.1.54](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.54)
 
 **Release Date:** 2025-04-30

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+pytest-coverage-comment is a GitHub Action that comments on pull requests with pytest code coverage reports. It parses pytest coverage output (txt and xml formats) and JUnit XML test results to create detailed coverage comments with badges and HTML reports.
+
+## Development Commands
+
+### Build and Bundle
+```bash
+npm run build      # Bundle the action with ncc into dist/index.js
+npm run all        # Run lint, format, and build in sequence
+```
+
+### Code Quality
+```bash
+npm run lint       # Run ESLint on src/**/*.js
+npm run format     # Format code with Prettier
+npm run format-check # Check formatting without changing files
+```
+
+### Version Management
+```bash
+npm run bump-version # Increment patch version
+```
+
+### Local Testing
+The `src/cli.js` file contains a CLI tool for local testing of coverage parsing functionality. It can be run directly to test coverage report generation without GitHub Actions.
+
+## Architecture Overview
+
+The codebase is a Node.js GitHub Action with the following key components:
+
+### Entry Points
+- **src/index.js**: Main GitHub Action entry point that orchestrates the entire workflow
+- **src/cli.js**: CLI utility for local testing and development
+
+### Core Parsing Modules
+- **src/parse.js**: Parses pytest text coverage output (e.g., from `pytest --cov`)
+- **src/parseXml.js**: Parses XML coverage reports (e.g., from `pytest --cov-report=xml`)
+- **src/junitXml.js**: Parses JUnit XML test results for test statistics
+
+### Supporting Modules
+- **src/multiFiles.js**: Handles multiple coverage files (useful for monorepos)
+- **src/utils.js**: Shared utilities for file operations, color determination, and GitHub API interactions
+
+### Data Flow
+1. Action receives coverage files (txt/xml) and JUnit XML as inputs
+2. Parsers extract coverage percentages, file details, and test statistics
+3. HTML report is generated with file links pointing to the repository
+4. Comment is created/updated on PR using GitHub API with coverage badge and collapsible report
+
+### GitHub Integration
+- Uses `@actions/core` for input/output handling
+- Uses `@actions/github` for API interactions (creating/updating PR comments)
+- Supports comment watermarking to update existing comments instead of creating duplicates
+
+## Key Implementation Details
+
+- Coverage thresholds for badge colors: 0-40% (red), 40-60% (orange), 60-80% (yellow), 80-90% (green), 90-100% (brightgreen)
+- Maximum comment length: 65,536 characters (GitHub limit)
+- Supports filtering to show only changed files in the current commit
+- Can skip files with 100% coverage from XML reports
+- Handles both absolute and relative file paths for coverage inputs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pytest-coverage-comment",
-  "version": "1.1.54",
+  "version": "1.1.55",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pytest-coverage-comment",
-      "version": "1.1.54",
+      "version": "1.1.55",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "devDependencies": {
         "@vercel/ncc": "^0.38.3",
         "eslint": "^8.57.1",
-        "prettier": "^3.5.3"
+        "prettier": "^3.6.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -384,9 +384,9 @@
       "integrity": "sha512-/6FKxSTWoJdbsLDF8tdIjaRiFXiE6UHsEHE3OPI/cwPURCVi1ukP0gmLn7XWEiFk5TcwQjjY5PWsU+j+tgXgmw=="
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1131,9 +1131,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
-      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -1707,9 +1707,9 @@
       "integrity": "sha512-/6FKxSTWoJdbsLDF8tdIjaRiFXiE6UHsEHE3OPI/cwPURCVi1ukP0gmLn7XWEiFk5TcwQjjY5PWsU+j+tgXgmw=="
     },
     "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -2271,9 +2271,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
-      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true
     },
     "punycode": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@vercel/ncc": "^0.38.3",
     "eslint": "^8.57.1",
-    "prettier": "^3.5.3"
+    "prettier": "^3.6.2"
   },
   "prettier": {
     "semi": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pytest-coverage-comment",
-  "version": "1.1.54",
+  "version": "1.1.55",
   "description": "Comments a pull request with the pytest code coverage badge, full report and tests summary",
   "author": "Misha Kav",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -10,12 +10,37 @@ const {
 const { getMultipleReport } = require('./multiFiles');
 
 const MAX_COMMENT_LENGTH = 65536;
+const MAX_SUMMARY_LENGTH = 1024 * 1024; // 1MB limit for GitHub step summary
 const FILE_STATUSES = Object.freeze({
   ADDED: 'added',
   MODIFIED: 'modified',
   REMOVED: 'removed',
   RENAMED: 'renamed',
 });
+
+const truncateSummary = (content, maxLength) => {
+  if (content.length <= maxLength) {
+    return content;
+  }
+
+  // prettier-ignore
+  const truncationMessage = '\n\n**Warning: Summary truncated due to GitHub\'s 1MB limit**';
+  const messageLength = truncationMessage.length;
+  // prettier-ignore
+  const truncatedContent = content.substring(0, maxLength - messageLength - 100); // Leave some buffer
+
+  // Try to find a good break point (end of line or closing tag)
+  const lastNewline = truncatedContent.lastIndexOf('\n');
+  const lastClosingTag = truncatedContent.lastIndexOf('</');
+  const breakPoint = Math.max(lastNewline, lastClosingTag);
+
+  // If we found a good break point
+  if (breakPoint > maxLength * 0.8) {
+    return truncatedContent.substring(0, breakPoint) + truncationMessage;
+  }
+
+  return truncatedContent + truncationMessage;
+};
 
 const createOrEditComment = async (
   octokit,
@@ -276,7 +301,12 @@ const main = async () => {
     eventName === 'workflow_dispatch' ||
     eventName === 'workflow_run'
   ) {
-    await core.summary.addRaw(body, true).write();
+    const truncatedBody = truncateSummary(body, MAX_SUMMARY_LENGTH);
+    if (body.length > MAX_SUMMARY_LENGTH) {
+      // prettier-ignore
+      core.warning(`GitHub step summary was truncated from ${body.length} to ${truncatedBody.length} characters due to the 1MB limit.`);
+    }
+    await core.summary.addRaw(truncatedBody, true).write();
     if (!issueNumberInput) {
       // prettier-ignore
       core.warning(`To use this action on a \`${eventName}\`, you need to pass an pull request number.`)


### PR DESCRIPTION
### ✨ PR Description
Purpose: Fix GitHub step summary truncation to prevent failures when summaries exceed GitHub's 1MB limit.
Main changes:
- Added truncateSummary function that smartly cuts content at logical break points
- Implemented automatic detection and handling of oversized GitHub step summaries
- Updated version to 1.1.55 with changelog entry for the fix

_Generated by LinearB AI and added by gitStream._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Step summaries in GitHub Actions are now automatically truncated if they exceed 1MB, with a warning message included when truncation occurs.

* **Bug Fixes**
  * Resolved errors caused by exceeding GitHub Action Summary size limits.

* **Documentation**
  * Added a CLAUDE.md file with detailed project and architecture guidance.
  * Updated the changelog with release notes for version 1.1.55.

* **Chores**
  * Updated development dependencies and bumped the package version to 1.1.55.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->