### PR TITLE
Small grammar fix [skip ci]

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -18996,7 +18996,7 @@ const main = async () => {
     await core.summary.addRaw(truncatedBody, true).write();
     if (!issueNumberInput) {
       // prettier-ignore
-      core.warning(`To use this action on a \`${eventName}\`, you need to pass an pull request number.`)
+      core.warning(`To use this action on a \`${eventName}\`, you need to pass a pull request number.`)
     } else {
       if (createNewComment) {
         core.info('Creating a new comment');

--- a/src/index.js
+++ b/src/index.js
@@ -309,7 +309,7 @@ const main = async () => {
     await core.summary.addRaw(truncatedBody, true).write();
     if (!issueNumberInput) {
       // prettier-ignore
-      core.warning(`To use this action on a \`${eventName}\`, you need to pass an pull request number.`)
+      core.warning(`To use this action on a \`${eventName}\`, you need to pass a pull request number.`)
     } else {
       if (createNewComment) {
         core.info('Creating a new comment');


### PR DESCRIPTION
### ✨ PR Description
Purpose: Fix grammatical error in warning message to improve readability and professionalism of error output.
Main changes:
- Changed "an pull request number" to "a pull request number" in the warning message

_Generated by LinearB AI and added by gitStream._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a grammatical error in a warning message to improve clarity for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->