### PR TITLE
Fix invalid syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog of the Pytest Coverage Comment
 
+## [Pytest Coverage Comment 1.1.56](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.56)
+
+**Release Date:** 2025-08-09
+
+#### Changes
+
+- fix GitHub Actions matrix syntax parsing error in action.yml (#214)
+
 ## [Pytest Coverage Comment 1.1.55](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.55)
 
 **Release Date:** 2025-08-09

--- a/action.yml
+++ b/action.yml
@@ -100,7 +100,7 @@ inputs:
     required: false
 
   unique-id-for-comment:
-    description: 'Unique identifier for matrix builds to update separate comments (e.g., ${{ matrix.python-version }})'
+    description: 'Unique identifier for matrix builds to update separate comments (e.g., matrix.python-version)'
     default: ''
     required: false
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pytest-coverage-comment",
-  "version": "1.1.55",
+  "version": "1.1.56",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pytest-coverage-comment",
-      "version": "1.1.55",
+      "version": "1.1.56",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pytest-coverage-comment",
-  "version": "1.1.55",
+  "version": "1.1.56",
   "description": "Comments a pull request with the pytest code coverage badge, full report and tests summary",
   "author": "Misha Kav",
   "license": "MIT",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the changelog with a new entry for version 1.1.56, highlighting a fix for a GitHub Actions matrix syntax parsing error.
  * Clarified the example usage in the input parameter description for GitHub Actions configuration.

* **Chores**
  * Bumped the version number to 1.1.56.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->