### PR TITLE
Fix/issue 204 coverageHtml empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog of the Pytest Coverage Comment
 
+## [Pytest Coverage Comment 1.1.57](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.57)
+
+**Release Date:** 2025-08-30
+
+#### Changes
+
+- fix coverageHtml output empty when using XML coverage files (#204)
+- ensure proper HTML generation for both text and XML coverage file types
+
 ## [Pytest Coverage Comment 1.1.56](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.56)
 
 **Release Date:** 2025-08-09

--- a/dist/index.js
+++ b/dist/index.js
@@ -18884,7 +18884,9 @@ const main = async () => {
 
   if (html) {
     const newOptions = { ...options, commit: defaultBranch };
-    const output = getCoverageReport(newOptions);
+    const output = newOptions.covXmlFile
+      ? getCoverageXmlReport(newOptions)
+      : getCoverageReport(newOptions);
     core.setOutput('coverageHtml', output.html);
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pytest-coverage-comment",
-  "version": "1.1.56",
+  "version": "1.1.57",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pytest-coverage-comment",
-      "version": "1.1.56",
+      "version": "1.1.57",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pytest-coverage-comment",
-  "version": "1.1.56",
+  "version": "1.1.57",
   "description": "Comments a pull request with the pytest code coverage badge, full report and tests summary",
   "author": "Misha Kav",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -192,7 +192,9 @@ const main = async () => {
 
   if (html) {
     const newOptions = { ...options, commit: defaultBranch };
-    const output = getCoverageReport(newOptions);
+    const output = newOptions.covXmlFile
+      ? getCoverageXmlReport(newOptions)
+      : getCoverageReport(newOptions);
     core.setOutput('coverageHtml', output.html);
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved issue where HTML coverage output could be empty when using XML coverage files.
  * Ensured consistent HTML report generation for both text and XML coverage inputs, improving reliability of coverage comments in CI.

* **Documentation**
  * Updated changelog for version 1.1.57 with details of fixes and release date.

* **Chores**
  * Bumped application version to 1.1.57.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->