### PR TITLE
Add XML Coverage Support in Multiline Mode

### DIFF
--- a/.github/workflows/multiline-xml-multiple-files.yml
+++ b/.github/workflows/multiline-xml-multiple-files.yml
@@ -1,0 +1,44 @@
+name: Multiline XML Coverage
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+
+jobs:
+  unit-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install
+        run: npm ci
+
+      - name: Lint/Format/Build
+        run: npm run all
+
+      - name: Run multiline tests
+        run: npm test
+
+  exercise-action-multiline:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use local Action with multiple-files (TXT + XML coverage)
+        uses: ./
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          multiple-files: |
+            TXT Sample, ./data/pytest-coverage_4.txt, ./data/pytest_1.xml
+            XML Sample, ./data/coverage_1.xml, ./data/pytest_1.xml
+          hide-comment: true
+          remove-link-from-badge: true
+          default-branch: main

--- a/action.yml
+++ b/action.yml
@@ -90,7 +90,9 @@ inputs:
     description: >
       Generate single comment with multiple coverage reports (useful for monorepos).
       Format: One report per line as "Title, coverage-path, junit-path".
-      Example: "Backend API, ./backend/coverage.txt, ./backend/junit.xml"
+      Coverage path can be TXT (from --cov-report=term-missing) or XML (from --cov-report=xml).
+      Examples: "Backend API, ./backend/coverage.txt, ./backend/junit.xml"
+      "Frontend Tests, ./frontend/coverage.xml, ./frontend/junit.xml"
     default: ''
     required: false
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -216,6 +216,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
       "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^2.4.4",
         "@octokit/graphql": "^4.5.8",
@@ -325,6 +326,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -532,6 +534,7 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -1563,6 +1566,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
       "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
+      "peer": true,
       "requires": {
         "@octokit/auth-token": "^2.4.4",
         "@octokit/graphql": "^4.5.8",
@@ -1662,7 +1666,8 @@
       "version": "8.14.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -1824,6 +1829,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "lint": "eslint src/**/*.js",
     "build": "ncc build src/index.js --license licenses.txt",
     "bump-version": "npm version patch",
-    "all": "npm run lint && npm run format && npm run build"
+    "all": "npm run lint && npm run format && npm run build",
+    "test": "node test/multiple-files.test.js"
   },
   "dependencies": {
     "@actions/core": "^1.11.1",

--- a/src/multiFiles.js
+++ b/src/multiFiles.js
@@ -1,4 +1,5 @@
 const { getCoverageReport } = require('./parse');
+const { getCoverageXmlReport } = require('./parseXml');
 const { getParsedXml } = require('./junitXml');
 const core = require('@actions/core');
 
@@ -18,14 +19,19 @@ const parseLine = (line) => {
 };
 
 // make internal options
-const getOptions = (options = {}, line = {}) => ({
-  ...options,
-  title: line.title,
-  covFile: line.covFile,
-  hideReport: true,
-  xmlFile: line.xmlFile,
-  xmlTitle: '',
-});
+const getOptions = (options = {}, line = {}) => {
+  const isXmlCoverage =
+    line.covFile && line.covFile.toLowerCase().endsWith('.xml');
+  return {
+    ...options,
+    title: line.title,
+    covFile: isXmlCoverage ? '' : line.covFile,
+    covXmlFile: isXmlCoverage ? line.covFile : '',
+    hideReport: true,
+    xmlFile: line.xmlFile,
+    xmlTitle: '',
+  };
+};
 
 // return multiple report in markdown format
 const getMultipleReport = (options) => {
@@ -44,25 +50,38 @@ const getMultipleReport = (options) => {
 
     lineReports.forEach((l, i) => {
       const internalOptions = getOptions(options, l);
-      const coverage = getCoverageReport(internalOptions);
+      const report = internalOptions.covXmlFile
+        ? getCoverageXmlReport(internalOptions)
+        : getCoverageReport(internalOptions);
       const summary = getParsedXml(internalOptions);
 
-      if (coverage.html) {
-        table += `| ${l.title} | ${coverage.html}`;
+      if (report.html) {
+        table += `| ${l.title} | ${report.html}`;
 
         if (i === 0) {
-          core.startGroup(internalOptions.covFile);
-          core.info(`coverage: ${coverage.coverage}`);
-          core.info(`color: ${coverage.color}`);
-          core.info(`warnings: ${coverage.warnings}`);
+          core.startGroup(
+            internalOptions.covXmlFile || internalOptions.covFile,
+          );
+          const coverageValue = internalOptions.covXmlFile
+            ? report.coverage.cover
+            : report.coverage;
+          core.info(`coverage: ${coverageValue}`);
+          core.info(`color: ${report.color}`);
+          if (!internalOptions.covXmlFile) {
+            core.info(`warnings: ${report.warnings}`);
+          }
           core.endGroup();
 
-          core.setOutput('coverage', coverage.coverage);
-          core.setOutput('color', coverage.color);
-          core.setOutput('warnings', coverage.warnings);
+          core.setOutput('coverage', coverageValue);
+          core.setOutput('color', report.color);
+          if (!internalOptions.covXmlFile) {
+            core.setOutput('warnings', report.warnings);
+          }
 
           const newOptions = { ...internalOptions, commit: defaultBranch };
-          const output = getCoverageReport(newOptions);
+          const output = newOptions.covXmlFile
+            ? getCoverageXmlReport(newOptions)
+            : getCoverageReport(newOptions);
           core.setOutput('coverageHtml', output.html);
 
           if (summary) {

--- a/test/multiple-files.test.js
+++ b/test/multiple-files.test.js
@@ -1,0 +1,63 @@
+/* eslint-disable no-console */
+const assert = require('assert');
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+
+process.env.GITHUB_WORKSPACE = path.resolve(__dirname, '..');
+const ghaOutput = path.join(os.tmpdir(), 'gha_output.txt');
+try { fs.writeFileSync(ghaOutput, ''); } catch (_) {}
+process.env.GITHUB_OUTPUT = ghaOutput;
+
+const { getMultipleReport } = require('../src/multiFiles');
+
+const abs = (p) => path.resolve(__dirname, '..', p);
+
+(async () => {
+  const options = {
+    // inherited by line internals
+    repository: 'owner/repo',
+    repoUrl: 'https://github.com/owner/repo',
+    commit: 'main',
+    defaultBranch: 'main',
+    badgeTitle: 'Coverage',
+    title: 'Coverage Report',
+    hideBadge: false,
+    hideReport: false,
+    removeLinkFromBadge: true,
+
+    // important: two lines — one TXT coverage, one XML coverage
+    multipleFiles: [
+      `TXT Title, ${abs('data/pytest-coverage_4.txt')}, ${abs('data/pytest_1.xml')}`,
+      `XML Title, ${abs('data/coverage_1.xml')}, ${abs('data/pytest_1.xml')}`,
+    ],
+  };
+
+  const table = getMultipleReport(options);
+
+  // Basic presence checks
+  assert.ok(table && typeof table === 'string', 'Table should be a non-empty string');
+
+  // Header should include Tests columns (since junit xml provided)
+  assert.ok(table.includes('| Title | Coverage | Tests | Skipped | Failures | Errors | Time |'),
+    'Header with Tests/Skipped/Failures/Errors/Time should be present');
+
+  // Titles present
+  assert.ok(table.includes('TXT Title'), 'TXT title row present');
+  assert.ok(table.includes('XML Title'), 'XML title row present');
+
+  // Badge present (from toHtml)
+  assert.ok(table.includes('img.shields.io/badge'), 'Badge should be present');
+
+  // JUnit summary columns should be filled for both rows
+  // Skipped/failures/errors/time icons present
+  assert.ok(table.includes(':zzz:'), 'Skipped emoji should be present');
+  assert.ok(table.includes(':x:'), 'Failures emoji should be present');
+  assert.ok(table.includes(':fire:'), 'Errors emoji should be present');
+  assert.ok(table.includes(':stopwatch:'), 'Time emoji should be present');
+
+  console.log('OK: multiple-files TXT and XML coverage supported.');
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Add XML Coverage Support in Multiline Mode

fixes MishaKav/pytest-coverage-comment#200 

### What Changed
- **Enhanced `multiple-files` input** to support XML coverage files in addition to TXT
- **Automatic detection** of XML coverage by `.xml` file extension (case-insensitive)
- **Backward compatible** - existing TXT coverage files continue to work unchanged

### Key Features
- **Mixed formats**: Can now mix TXT and XML coverage files in the same multiline input
- **Smart parsing**: Automatically chooses the correct parser (TXT vs XML) based on file extension
- **Proper outputs**: Only sets `warnings` output for TXT coverage (XML doesn't provide warnings)
- **Updated docs**: Enhanced `action.yml` with examples showing both TXT and XML usage

### Example Usage
```yaml
multiple-files: |
  Backend API, ./backend/coverage.txt, ./backend/junit.xml
  Frontend Tests, ./frontend/coverage.xml, ./frontend/junit.xml
```

### Testing
- Added unit tests for multiline XML coverage support
- Added GitHub workflow to test both TXT and XML coverage in multiline mode
- All existing functionality preserved

### Files Modified
- `src/multiFiles.js` - Core multiline parsing logic
- `action.yml` - Updated documentation with XML examples
- `package.json` - Added test script
- Added test files and GitHub workflow

This enables monorepo users to use different coverage report formats (TXT vs XML) for different components while maintaining a single unified comment.