### PR TITLE
Fix running in annotated git tag GitHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog of the Pytest Coverage Comment
 
+## [Pytest Coverage Comment 1.1.58](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.58)
+
+**Release Date:** 2025-11-08
+
+#### Changes
+
+- fix handling of annotated git tags in push events (#195)
+- update `@actions/github` from v4.0.0 to v6.0.1 (#229)
+- fix 3 security vulnerabilities in Octokit dependencies
+
 ## [Pytest Coverage Comment 1.1.57](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.57)
 
 **Release Date:** 2025-08-30

--- a/dist/index.js
+++ b/dist/index.js
@@ -18786,7 +18786,7 @@ const createOrEditComment = async (
   WATERMARK,
 ) => {
   // Now decide if we should issue a new comment or edit an old one
-  const { data: comments } = await octokit.issues.listComments({
+  const { data: comments } = await octokit.rest.issues.listComments({
     repo,
     owner,
     issue_number,
@@ -18796,7 +18796,7 @@ const createOrEditComment = async (
 
   if (comment) {
     core.info('Found previous comment, updating');
-    await octokit.issues.updateComment({
+    await octokit.rest.issues.updateComment({
       repo,
       owner,
       comment_id: comment.id,
@@ -18804,7 +18804,7 @@ const createOrEditComment = async (
     });
   } else {
     core.info('No previous comment found, creating a new one');
-    await octokit.issues.createComment({
+    await octokit.rest.issues.createComment({
       repo,
       owner,
       issue_number,
@@ -19039,7 +19039,7 @@ const main = async () => {
 
   if (eventName === 'push') {
     core.info('Create commit comment');
-    await octokit.repos.createCommitComment({
+    await octokit.rest.repos.createCommitComment({
       repo,
       owner,
       commit_sha: options.commit,
@@ -19052,7 +19052,7 @@ const main = async () => {
     if (createNewComment) {
       core.info('Creating a new comment');
 
-      await octokit.issues.createComment({
+      await octokit.rest.issues.createComment({
         repo,
         owner,
         issue_number,
@@ -19084,7 +19084,7 @@ const main = async () => {
     } else {
       if (createNewComment) {
         core.info('Creating a new comment');
-        await octokit.issues.createComment({
+        await octokit.rest.issues.createComment({
           repo,
           owner,
           issue_number,
@@ -19134,7 +19134,7 @@ const getChangedFiles = async (options, pr_number) => {
         break;
       case 'workflow_run':
       case 'workflow_dispatch': {
-        const { data } = await octokit.pulls.get({
+        const { data } = await octokit.rest.pulls.get({
           owner,
           repo,
           pull_number: pr_number,

--- a/dist/index.js
+++ b/dist/index.js
@@ -18744,6 +18744,7 @@ const resolveCommitSha = async (octokit, owner, repo, sha, ref) => {
     } catch (error) {
       // If getTag fails, it might be a lightweight tag or direct commit
       // In this case, the SHA is already a commit SHA
+      // prettier-ignore
       core.info(`SHA is not an annotated tag object, using as commit SHA: ${sha}`);
       core.debug(`Error details: ${error.message}`);
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -18710,6 +18710,49 @@ const FILE_STATUSES = Object.freeze({
   RENAMED: 'renamed',
 });
 
+/**
+ * Resolves a potential tag object SHA to the underlying commit SHA.
+ * For annotated tags, GitHub's push event payload.after contains the tag object SHA,
+ * not the commit SHA. This function detects tag pushes and resolves them to commits.
+ *
+ * @param {object} octokit - GitHub API client
+ * @param {string} owner - Repository owner
+ * @param {string} repo - Repository name
+ * @param {string} sha - SHA to resolve (might be tag object or commit)
+ * @param {string} ref - Git ref (e.g., refs/tags/v1.0.0 or refs/heads/main)
+ * @returns {Promise<string>} - The commit SHA
+ */
+const resolveCommitSha = async (octokit, owner, repo, sha, ref) => {
+  // Check if this is a tag push
+  if (ref && ref.startsWith('refs/tags/')) {
+    try {
+      core.info(`Detected tag push: ${ref}`);
+      core.info(`Attempting to resolve SHA: ${sha}`);
+
+      // Try to get the tag object
+      const { data: tag } = await octokit.rest.git.getTag({
+        owner,
+        repo,
+        tag_sha: sha,
+      });
+
+      // If it's an annotated tag, it will have an object field pointing to the commit
+      if (tag && tag.object && tag.object.sha) {
+        core.info(`Resolved annotated tag to commit: ${tag.object.sha}`);
+        return tag.object.sha;
+      }
+    } catch (error) {
+      // If getTag fails, it might be a lightweight tag or direct commit
+      // In this case, the SHA is already a commit SHA
+      core.info(`SHA is not an annotated tag object, using as commit SHA: ${sha}`);
+      core.debug(`Error details: ${error.message}`);
+    }
+  }
+
+  // Return original SHA if not a tag or if it's a lightweight tag
+  return sha;
+};
+
 const truncateSummary = (content, maxLength) => {
   if (content.length <= maxLength) {
     return content;
@@ -18847,12 +18890,23 @@ const main = async () => {
   options.repoUrl =
     payload.repository?.html_url || `https://github.com/${options.repository}`;
 
+  // Initialize octokit early so we can use it for tag resolution
+  const octokit = github.getOctokit(token);
+
   if (eventName === 'pull_request' || eventName === 'pull_request_target') {
     options.commit = payload.pull_request.head.sha;
     options.head = payload.pull_request.head.ref;
     options.base = payload.pull_request.base.ref;
   } else if (eventName === 'push') {
-    options.commit = payload.after;
+    // For annotated tags, payload.after contains the tag object SHA, not the commit SHA
+    // Resolve it to the actual commit SHA
+    options.commit = await resolveCommitSha(
+      octokit,
+      owner,
+      repo,
+      payload.after,
+      context.ref,
+    );
     options.head = context.ref;
   } else if (eventName === 'workflow_dispatch') {
     options.commit = context.sha;
@@ -18976,7 +19030,6 @@ const main = async () => {
     return;
   }
   const body = WATERMARK + finalHtml;
-  const octokit = github.getOctokit(token);
 
   const issue_number = payload.pull_request
     ? payload.pull_request.number
@@ -19075,7 +19128,9 @@ const getChangedFiles = async (options, pr_number) => {
         break;
       case 'push':
         base = payload.before;
-        head = payload.after;
+        // Use the resolved commit SHA from options instead of payload.after
+        // This handles annotated tags correctly
+        head = options.commit || payload.after;
         break;
       case 'workflow_run':
       case 'workflow_dispatch': {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pytest-coverage-comment",
-  "version": "1.1.57",
+  "version": "1.1.58",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pytest-coverage-comment",
-      "version": "1.1.57",
+      "version": "1.1.58",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pytest-coverage-comment",
-  "version": "1.1.57",
+  "version": "1.1.58",
   "description": "Comments a pull request with the pytest code coverage badge, full report and tests summary",
   "author": "Misha Kav",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -94,7 +94,7 @@ const createOrEditComment = async (
   WATERMARK,
 ) => {
   // Now decide if we should issue a new comment or edit an old one
-  const { data: comments } = await octokit.issues.listComments({
+  const { data: comments } = await octokit.rest.issues.listComments({
     repo,
     owner,
     issue_number,
@@ -104,7 +104,7 @@ const createOrEditComment = async (
 
   if (comment) {
     core.info('Found previous comment, updating');
-    await octokit.issues.updateComment({
+    await octokit.rest.issues.updateComment({
       repo,
       owner,
       comment_id: comment.id,
@@ -112,7 +112,7 @@ const createOrEditComment = async (
     });
   } else {
     core.info('No previous comment found, creating a new one');
-    await octokit.issues.createComment({
+    await octokit.rest.issues.createComment({
       repo,
       owner,
       issue_number,
@@ -347,7 +347,7 @@ const main = async () => {
 
   if (eventName === 'push') {
     core.info('Create commit comment');
-    await octokit.repos.createCommitComment({
+    await octokit.rest.repos.createCommitComment({
       repo,
       owner,
       commit_sha: options.commit,
@@ -360,7 +360,7 @@ const main = async () => {
     if (createNewComment) {
       core.info('Creating a new comment');
 
-      await octokit.issues.createComment({
+      await octokit.rest.issues.createComment({
         repo,
         owner,
         issue_number,
@@ -392,7 +392,7 @@ const main = async () => {
     } else {
       if (createNewComment) {
         core.info('Creating a new comment');
-        await octokit.issues.createComment({
+        await octokit.rest.issues.createComment({
           repo,
           owner,
           issue_number,
@@ -442,7 +442,7 @@ const getChangedFiles = async (options, pr_number) => {
         break;
       case 'workflow_run':
       case 'workflow_dispatch': {
-        const { data } = await octokit.pulls.get({
+        const { data } = await octokit.rest.pulls.get({
           owner,
           repo,
           pull_number: pr_number,

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,49 @@ const FILE_STATUSES = Object.freeze({
   RENAMED: 'renamed',
 });
 
+/**
+ * Resolves a potential tag object SHA to the underlying commit SHA.
+ * For annotated tags, GitHub's push event payload.after contains the tag object SHA,
+ * not the commit SHA. This function detects tag pushes and resolves them to commits.
+ *
+ * @param {object} octokit - GitHub API client
+ * @param {string} owner - Repository owner
+ * @param {string} repo - Repository name
+ * @param {string} sha - SHA to resolve (might be tag object or commit)
+ * @param {string} ref - Git ref (e.g., refs/tags/v1.0.0 or refs/heads/main)
+ * @returns {Promise<string>} - The commit SHA
+ */
+const resolveCommitSha = async (octokit, owner, repo, sha, ref) => {
+  // Check if this is a tag push
+  if (ref && ref.startsWith('refs/tags/')) {
+    try {
+      core.info(`Detected tag push: ${ref}`);
+      core.info(`Attempting to resolve SHA: ${sha}`);
+
+      // Try to get the tag object
+      const { data: tag } = await octokit.rest.git.getTag({
+        owner,
+        repo,
+        tag_sha: sha,
+      });
+
+      // If it's an annotated tag, it will have an object field pointing to the commit
+      if (tag && tag.object && tag.object.sha) {
+        core.info(`Resolved annotated tag to commit: ${tag.object.sha}`);
+        return tag.object.sha;
+      }
+    } catch (error) {
+      // If getTag fails, it might be a lightweight tag or direct commit
+      // In this case, the SHA is already a commit SHA
+      core.info(`SHA is not an annotated tag object, using as commit SHA: ${sha}`);
+      core.debug(`Error details: ${error.message}`);
+    }
+  }
+
+  // Return original SHA if not a tag or if it's a lightweight tag
+  return sha;
+};
+
 const truncateSummary = (content, maxLength) => {
   if (content.length <= maxLength) {
     return content;
@@ -155,12 +198,23 @@ const main = async () => {
   options.repoUrl =
     payload.repository?.html_url || `https://github.com/${options.repository}`;
 
+  // Initialize octokit early so we can use it for tag resolution
+  const octokit = github.getOctokit(token);
+
   if (eventName === 'pull_request' || eventName === 'pull_request_target') {
     options.commit = payload.pull_request.head.sha;
     options.head = payload.pull_request.head.ref;
     options.base = payload.pull_request.base.ref;
   } else if (eventName === 'push') {
-    options.commit = payload.after;
+    // For annotated tags, payload.after contains the tag object SHA, not the commit SHA
+    // Resolve it to the actual commit SHA
+    options.commit = await resolveCommitSha(
+      octokit,
+      owner,
+      repo,
+      payload.after,
+      context.ref,
+    );
     options.head = context.ref;
   } else if (eventName === 'workflow_dispatch') {
     options.commit = context.sha;
@@ -284,7 +338,6 @@ const main = async () => {
     return;
   }
   const body = WATERMARK + finalHtml;
-  const octokit = github.getOctokit(token);
 
   const issue_number = payload.pull_request
     ? payload.pull_request.number
@@ -383,7 +436,9 @@ const getChangedFiles = async (options, pr_number) => {
         break;
       case 'push':
         base = payload.before;
-        head = payload.after;
+        // Use the resolved commit SHA from options instead of payload.after
+        // This handles annotated tags correctly
+        head = options.commit || payload.after;
         break;
       case 'workflow_run':
       case 'workflow_dispatch': {

--- a/src/index.js
+++ b/src/index.js
@@ -52,6 +52,7 @@ const resolveCommitSha = async (octokit, owner, repo, sha, ref) => {
     } catch (error) {
       // If getTag fails, it might be a lightweight tag or direct commit
       // In this case, the SHA is already a commit SHA
+      // prettier-ignore
       core.info(`SHA is not an annotated tag object, using as commit SHA: ${sha}`);
       core.debug(`Error details: ${error.message}`);
     }


### PR DESCRIPTION


## What does this PR do?

Resolves issue where the action failed when triggered by annotated tag pushes with error "No commit found for SHA". The problem occurred because payload.after contains the tag object's SHA for annotated tags, not the commit SHA.

Changes:
- Added resolveCommitSha() helper function to detect tag pushes and resolve annotated tag objects to their underlying commit SHA using GitHub's Git Data API
- Initialize octokit early in main() to enable tag resolution before setting options.commit
- Updated getChangedFiles() to use the resolved commit SHA from options
- Gracefully handles both annotated tags (resolves to commit) and lightweight tags (already contain commit SHA)

The fix ensures createCommitComment() receives a valid commit SHA regardless of whether the push event was triggered by a regular commit, lightweight tag, or annotated tag.

## Related Issue

Closes #195
