### PR TITLE
Add serverUrl for self hosted GitHub

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -39505,6 +39505,9 @@ const main = async () => {
   const { context, repository } = github;
   const { repo, owner } = context.repo;
   const { eventName, payload } = context;
+  const serverUrl = context.serverUrl || 'https://github.com';
+
+  core.info(`Uses Github URL: ${serverUrl}`);
   const watermarkUniqueId = uniqueIdForComment
     ? `| ${uniqueIdForComment} `
     : '';
@@ -39536,7 +39539,7 @@ const main = async () => {
   };
 
   options.repoUrl =
-    payload.repository?.html_url || `https://github.com/${options.repository}`;
+    payload.repository?.html_url || `${serverUrl}/${options.repository}`;
 
   // Initialize octokit early so we can use it for tag resolution
   const octokit = github.getOctokit(token);

--- a/src/index.js
+++ b/src/index.js
@@ -198,6 +198,9 @@ const main = async () => {
   const { context, repository } = github;
   const { repo, owner } = context.repo;
   const { eventName, payload } = context;
+  const serverUrl = context.serverUrl || 'https://github.com';
+
+  core.info(`Uses Github URL: ${serverUrl}`);
   const watermarkUniqueId = uniqueIdForComment
     ? `| ${uniqueIdForComment} `
     : '';
@@ -229,7 +232,7 @@ const main = async () => {
   };
 
   options.repoUrl =
-    payload.repository?.html_url || `https://github.com/${options.repository}`;
+    payload.repository?.html_url || `${serverUrl}/${options.repository}`;
 
   // Initialize octokit early so we can use it for tag resolution
   const octokit = github.getOctokit(token);


### PR DESCRIPTION
Implemented automatic server URL detection to support self-hosted GitHub instances

- serverUrl is automatically calculated from context.serverUrl
- Falls back to 'https://github.com' for standard GitHub
- Updated repoUrl construction to use serverUrl for file links
- Added logging to show which GitHub URL is being used

This allows users running GitHub Enterprise Server or other self-hosted GitHub instances to have coverage report links point to the correct server automatically, without requiring any additional configuration.
