### PR TITLE
Add text-instead-badge option implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@
 
 #### Changes
 
-- feat: add `text-instead-badge` option to display coverage as simple text instead of badge images
+- feat: add `text-instead-badge` option to display coverage as simple text instead of badge images (#235)
 - text format displays as `XX% (covered/total)` (e.g., `85% (42/50)`)
 - applies to all coverage reports: main summary and multiple-files tables
 - fully backward compatible - badge mode remains the default
+- feat: add automatic server URL detection for self-hosted GitHub instances (#234)
+
+**Note:** Starting from this version, version bumps follow conventional semantic versioning (MAJOR.MINOR.PATCH) instead of only bumping PATCH versions.
 
 ## [Pytest Coverage Comment 1.1.59](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.59)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog of the Pytest Coverage Comment
 
+## [Pytest Coverage Comment 1.2.0](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.2.0)
+
+**Release Date:** 2025-11-15
+
+#### Changes
+
+- feat: add `text-instead-badge` option to display coverage as simple text instead of badge images
+- text format displays as `XX% (covered/total)` (e.g., `85% (42/50)`)
+- applies to all coverage reports: main summary and multiple-files tables
+- fully backward compatible - badge mode remains the default
+
 ## [Pytest Coverage Comment 1.1.59](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.1.59)
 
 **Release Date:** 2025-11-08

--- a/README.md
+++ b/README.md
@@ -381,53 +381,6 @@ jobs:
 
 </details>
 
-### Complete Configuration
-
-<details>
-<summary>Complete example showing all available parameters</summary>
-
-```yaml
-- name: Pytest Coverage Comment
-  uses: MishaKav/pytest-coverage-comment@main
-  with:
-    # Core settings
-    github-token: ${{ secrets.GITHUB_TOKEN }}
-    pytest-coverage-path: ./pytest-coverage.txt
-    pytest-xml-coverage-path: ./coverage.xml
-    junitxml-path: ./pytest.xml
-
-    # Display options
-    title: Coverage Report
-    badge-title: Coverage
-    junitxml-title: Test Results
-    text-instead-badge: false
-    hide-badge: false
-    hide-report: false
-    hide-comment: false
-
-    # Filtering options
-    report-only-changed-files: false
-    xml-skip-covered: false
-
-    # Link options
-    remove-link-from-badge: false
-    remove-links-to-files: false
-    remove-links-to-lines: false
-
-    # Advanced options
-    create-new-comment: false
-    unique-id-for-comment: ''
-    default-branch: main
-    coverage-path-prefix: ''
-
-    # Monorepo support
-    multiple-files: |
-      Backend, ./backend/coverage.txt, ./backend/pytest.xml
-      Frontend, ./frontend/coverage.txt, ./frontend/pytest.xml
-```
-
-</details>
-
 ## 📋 Output Example
 
 Here's what the generated coverage comment looks like:

--- a/README.md
+++ b/README.md
@@ -443,8 +443,6 @@ Here's what the generated coverage comment looks like:
 <details>
 <summary>📝 Text-Based Coverage Display</summary>
 
-If you prefer simple text over badge images for coverage display:
-
 ```yaml
 - name: Coverage comment
   uses: MishaKav/pytest-coverage-comment@main
@@ -454,10 +452,7 @@ If you prefer simple text over badge images for coverage display:
     text-instead-badge: true
 ```
 
-This will display coverage as `85% (42/50)` instead of a badge image, which can be useful for:
-- Reducing external dependencies (no shields.io image loading)
-- Faster rendering in comments
-- Simpler, more minimal appearance
+Displays coverage as `85% (42/50)` instead of a badge image.
 
 </details>
 
@@ -599,22 +594,15 @@ If you want auto-update the coverage badge on your README, you can see the [work
 
 ### Text Mode (text-instead-badge: true)
 
-When using `text-instead-badge: true`, the coverage is displayed as simple text instead of a badge image:
+With `text-instead-badge: true`, coverage displays as simple text:
 
-**Example output:**
 ```
 85% (42/50)
 ```
 
-Instead of the default badge:
+Instead of a badge image:
 
 ![Coverage Badge](https://img.shields.io/badge/Coverage-85%25-green.svg)
-
-**Benefits:**
-- No external image dependencies (shields.io)
-- Faster rendering
-- More compact display
-- Better for minimalist styling
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ jobs:
 | `remove-link-from-badge`    | `false`           | Remove hyperlink from coverage badge (badge becomes plain image)    |
 | `remove-links-to-files`     | `false`           | Remove file links from coverage table to reduce comment size        |
 | `remove-links-to-lines`     | `false`           | Remove line number links from coverage table to reduce comment size |
+| `text-instead-badge`        | `false`           | Use simple text instead of badge images for coverage display        |
 
 </details>
 
@@ -391,6 +392,27 @@ Here's what the generated coverage comment looks like:
 | 109   | 2 :zzz: | 1 :x:    | 0 :fire: | 0.583s :stopwatch: |
 
 ## 🔬 Advanced Features
+
+<details>
+<summary>📝 Text-Based Coverage Display</summary>
+
+If you prefer simple text over badge images for coverage display:
+
+```yaml
+- name: Coverage comment
+  uses: MishaKav/pytest-coverage-comment@main
+  with:
+    pytest-coverage-path: ./pytest-coverage.txt
+    junitxml-path: ./pytest.xml
+    text-instead-badge: true
+```
+
+This will display coverage as `85% (42/50)` instead of a badge image, which can be useful for:
+- Reducing external dependencies (no shields.io image loading)
+- Faster rendering in comments
+- Simpler, more minimal appearance
+
+</details>
 
 <details>
 <summary>📊 Using Output Variables</summary>

--- a/README.md
+++ b/README.md
@@ -381,6 +381,53 @@ jobs:
 
 </details>
 
+### Complete Configuration
+
+<details>
+<summary>Complete example showing all available parameters</summary>
+
+```yaml
+- name: Pytest Coverage Comment
+  uses: MishaKav/pytest-coverage-comment@main
+  with:
+    # Core settings
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+    pytest-coverage-path: ./pytest-coverage.txt
+    pytest-xml-coverage-path: ./coverage.xml
+    junitxml-path: ./pytest.xml
+
+    # Display options
+    title: Coverage Report
+    badge-title: Coverage
+    junitxml-title: Test Results
+    text-instead-badge: false
+    hide-badge: false
+    hide-report: false
+    hide-comment: false
+
+    # Filtering options
+    report-only-changed-files: false
+    xml-skip-covered: false
+
+    # Link options
+    remove-link-from-badge: false
+    remove-links-to-files: false
+    remove-links-to-lines: false
+
+    # Advanced options
+    create-new-comment: false
+    unique-id-for-comment: ''
+    default-branch: main
+    coverage-path-prefix: ''
+
+    # Monorepo support
+    multiple-files: |
+      Backend, ./backend/coverage.txt, ./backend/pytest.xml
+      Frontend, ./frontend/coverage.txt, ./frontend/pytest.xml
+```
+
+</details>
+
 ## 📋 Output Example
 
 Here's what the generated coverage comment looks like:
@@ -549,6 +596,25 @@ If you want auto-update the coverage badge on your README, you can see the [work
 ### Multiple Files (Monorepo)
 
 ![Multiple Files](https://user-images.githubusercontent.com/289035/122121939-ddd0c500-ce34-11eb-8546-89a8a769e065.png)
+
+### Text Mode (text-instead-badge: true)
+
+When using `text-instead-badge: true`, the coverage is displayed as simple text instead of a badge image:
+
+**Example output:**
+```
+85% (42/50)
+```
+
+Instead of the default badge:
+
+![Coverage Badge](https://img.shields.io/badge/Coverage-85%25-green.svg)
+
+**Benefits:**
+- No external image dependencies (shields.io)
+- Faster rendering
+- More compact display
+- Better for minimalist styling
 
 </details>
 

--- a/action.yml
+++ b/action.yml
@@ -114,6 +114,11 @@ inputs:
     default: 'false'
     required: false
 
+  text-instead-badge:
+    description: 'Use simple text instead of badge images for coverage display'
+    default: 'false'
+    required: false
+
 outputs:
   coverage:
     description: 'Coverage percentage from pytest report (e.g., 85%)'

--- a/dist/index.js
+++ b/dist/index.js
@@ -36964,7 +36964,8 @@ const toHtml = (data, options, dataFromXml = null) => {
   const badgeWithLink = removeLinkFromBadge
     ? badge
     : `<a href="${readmeHref}">${badge}</a>`;
-  const textBadge = `${total.cover}% (${total.covered}/${total.statements})`;
+  const covered = total.stmts - total.miss;
+  const textBadge = `${total.cover} (${covered}/${total.stmts})`;
   const badgeContent = textInsteadBadge ? textBadge : badgeWithLink;
   const badgeHtml = hideBadge ? '' : badgeContent;
   const reportHtml = hideReport

--- a/dist/index.js
+++ b/dist/index.js
@@ -36953,6 +36953,7 @@ const toHtml = (data, options, dataFromXml = null) => {
     hideReport,
     reportOnlyChangedFiles,
     removeLinkFromBadge,
+    textInsteadBadge,
   } = options;
   const table = hideReport ? '' : toTable(data, options, dataFromXml);
   const total = dataFromXml ? dataFromXml.total : getTotal(data);
@@ -36963,7 +36964,9 @@ const toHtml = (data, options, dataFromXml = null) => {
   const badgeWithLink = removeLinkFromBadge
     ? badge
     : `<a href="${readmeHref}">${badge}</a>`;
-  const badgeHtml = hideBadge ? '' : badgeWithLink;
+  const textBadge = `${total.cover}% (${total.covered}/${total.statements})`;
+  const badgeContent = textInsteadBadge ? textBadge : badgeWithLink;
+  const badgeHtml = hideBadge ? '' : badgeContent;
   const reportHtml = hideReport
     ? ''
     : `<details><summary>${title} ${onlyChnaged}</summary>${table}</details>`;
@@ -39487,6 +39490,9 @@ const main = async () => {
   const removeLinksToLines = core.getBooleanInput('remove-links-to-lines', {
     required: false,
   });
+  const textInsteadBadge = core.getBooleanInput('text-instead-badge', {
+    required: false,
+  });
   const uniqueIdForComment = core.getInput('unique-id-for-comment', {
     required: false,
   });
@@ -39530,6 +39536,7 @@ const main = async () => {
     removeLinkFromBadge,
     removeLinksToFiles,
     removeLinksToLines,
+    textInsteadBadge,
     defaultBranch,
     xmlTitle,
     multipleFiles,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pytest-coverage-comment",
-  "version": "1.1.59",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pytest-coverage-comment",
-      "version": "1.1.59",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",
@@ -302,6 +302,7 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -463,6 +464,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -657,6 +659,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pytest-coverage-comment",
-  "version": "1.1.59",
+  "version": "1.2.0",
   "description": "Comments a pull request with the pytest code coverage badge, full report and tests summary",
   "author": "Misha Kav",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -180,6 +180,9 @@ const main = async () => {
   const removeLinksToLines = core.getBooleanInput('remove-links-to-lines', {
     required: false,
   });
+  const textInsteadBadge = core.getBooleanInput('text-instead-badge', {
+    required: false,
+  });
   const uniqueIdForComment = core.getInput('unique-id-for-comment', {
     required: false,
   });
@@ -223,6 +226,7 @@ const main = async () => {
     removeLinkFromBadge,
     removeLinksToFiles,
     removeLinksToLines,
+    textInsteadBadge,
     defaultBranch,
     xmlTitle,
     multipleFiles,

--- a/src/parse.js
+++ b/src/parse.js
@@ -205,7 +205,8 @@ const toHtml = (data, options, dataFromXml = null) => {
   const badgeWithLink = removeLinkFromBadge
     ? badge
     : `<a href="${readmeHref}">${badge}</a>`;
-  const textBadge = `${total.cover}% (${total.covered}/${total.statements})`;
+  const covered = total.stmts - total.miss;
+  const textBadge = `${total.cover} (${covered}/${total.stmts})`;
   const badgeContent = textInsteadBadge ? textBadge : badgeWithLink;
   const badgeHtml = hideBadge ? '' : badgeContent;
   const reportHtml = hideReport

--- a/src/parse.js
+++ b/src/parse.js
@@ -194,6 +194,7 @@ const toHtml = (data, options, dataFromXml = null) => {
     hideReport,
     reportOnlyChangedFiles,
     removeLinkFromBadge,
+    textInsteadBadge,
   } = options;
   const table = hideReport ? '' : toTable(data, options, dataFromXml);
   const total = dataFromXml ? dataFromXml.total : getTotal(data);
@@ -204,7 +205,9 @@ const toHtml = (data, options, dataFromXml = null) => {
   const badgeWithLink = removeLinkFromBadge
     ? badge
     : `<a href="${readmeHref}">${badge}</a>`;
-  const badgeHtml = hideBadge ? '' : badgeWithLink;
+  const textBadge = `${total.cover}% (${total.covered}/${total.statements})`;
+  const badgeContent = textInsteadBadge ? textBadge : badgeWithLink;
+  const badgeHtml = hideBadge ? '' : badgeContent;
   const reportHtml = hideReport
     ? ''
     : `<details><summary>${title} ${onlyChnaged}</summary>${table}</details>`;


### PR DESCRIPTION
## Description

Add `text-instead-badge` input option to display coverage as text instead of badge images.

## Changes

- Added `text-instead-badge` input to `action.yml` (default: `false`)
- Updated `src/index.js` and `src/parse.js` to support text format
- Text format: `85% (42/50)`
- Works with all coverage reports (main summary and multiple-files)
- Updated README with documentation

## Compatibility

Fully backward compatible - default behavior unchanged.