### PR TITLE
Add branch coverage support for text and XML formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog of the Pytest Coverage Comment
 
+## [Pytest Coverage Comment 1.4.0](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.4.0)
+
+**Release Date:** 2026-02-22
+
+#### Changes
+
+- feat: auto-detect and display branch coverage columns (`Branch`, `BrPart`) in coverage table (#110)
+- supported for both text format (`pytest --cov --cov-branch`) and XML format (`coverage.xml`)
+- no new action inputs required — columns appear automatically when branch data is present
+- fully backward compatible — existing users see no change
+
 ## [Pytest Coverage Comment 1.3.0](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.3.0)
 
 **Release Date:** 2026-02-21

--- a/dist/index.js
+++ b/dist/index.js
@@ -38429,8 +38429,9 @@ const parseTotalLine = (line, hasBranch = false) => {
   }
 
   const parsedLine = line.split('  ').filter((l) => l);
+  const minCols = hasBranch ? 6 : 4;
 
-  if (parsedLine.length < 4) {
+  if (parsedLine.length < minCols) {
     return null;
   }
 
@@ -38698,8 +38699,8 @@ const getTotalCoverage = (parsedXml) => {
   };
 
   if (branchesValid > 0) {
-    result.branch = branchesValid;
-    result.brpart = branchesValid - branchesCovered;
+    result.branch = branchesValid.toString();
+    result.brpart = (branchesValid - branchesCovered).toString();
   }
 
   return result;

--- a/dist/index.js
+++ b/dist/index.js
@@ -38290,6 +38290,15 @@ const isValidCoverageContent = (data) => {
   return wordsToInclude.every((w) => data.includes(w));
 };
 
+// return true if coverage data includes branch coverage columns
+const hasBranchCoverage = (data) => {
+  if (!data || !data.length) {
+    return false;
+  }
+
+  return data.includes('Branch') && data.includes('BrPart');
+};
+
 // return full html coverage report and coverage percentage
 const getCoverageReport = (options) => {
   const { covFile, covXmlFile } = options;
@@ -38351,8 +38360,9 @@ const getTotal = (data) => {
 
   const lines = data.split('\n');
   const line = lines.find((l) => l.includes('TOTAL    '));
+  const hasBranch = hasBranchCoverage(data);
 
-  return parseTotalLine(line);
+  return parseTotalLine(line, hasBranch);
 };
 
 // get number of warnings from coverage-file
@@ -38374,14 +38384,15 @@ const getWarnings = (data) => {
 };
 
 // parse one line from coverage-file
-const parseOneLine = (line) => {
+const parseOneLine = (line, hasBranch = false) => {
   if (!line) {
     return null;
   }
 
   const parsedLine = line.split('   ').filter((l) => l);
+  const minCols = hasBranch ? 6 : 4;
 
-  if (parsedLine.length < 4) {
+  if (parsedLine.length < minCols) {
     return null;
   }
 
@@ -38395,17 +38406,24 @@ const parseOneLine = (line) => {
     : parsedLine[parsedLine.length - 1] &&
       parsedLine[parsedLine.length - 1].split(', ');
 
-  return {
+  const result = {
     name: parsedLine[0],
     stmts: parsedLine[1].trim(),
     miss: parsedLine[2].trim(),
     cover,
     missing,
   };
+
+  if (hasBranch) {
+    result.branch = parsedLine[3].trim();
+    result.brpart = parsedLine[4].trim();
+  }
+
+  return result;
 };
 
 // parse total line from coverage-file
-const parseTotalLine = (line) => {
+const parseTotalLine = (line, hasBranch = false) => {
   if (!line) {
     return null;
   }
@@ -38416,12 +38434,19 @@ const parseTotalLine = (line) => {
     return null;
   }
 
-  return {
+  const result = {
     name: parsedLine[0],
     stmts: parsedLine[1].trim(),
     miss: parsedLine[2].trim(),
     cover: parsedLine[parsedLine.length - 1].trim(),
   };
+
+  if (hasBranch) {
+    result.branch = parsedLine[3].trim();
+    result.brpart = parsedLine[4].trim();
+  }
+
+  return result;
 };
 
 // parse coverage-file
@@ -38432,7 +38457,9 @@ const parse = (data) => {
     return null;
   }
 
-  return actualLines.map(parseOneLine);
+  const hasBranch = hasBranchCoverage(data);
+
+  return actualLines.map((line) => parseOneLine(line, hasBranch));
 };
 
 // collapse all lines to folders structure
@@ -38499,6 +38526,7 @@ const toTable = (data, options, dataFromXml = null) => {
   }
   const totalLine = dataFromXml ? dataFromXml.total : getTotal(data);
   options.hasMissing = coverage.some((c) => c.missing);
+  options.hasBranch = coverage.some((c) => c.branch !== undefined);
 
   core.info(`Generating coverage report`);
   const headTr = toHeadRow(options);
@@ -38545,9 +38573,11 @@ const toTable = (data, options, dataFromXml = null) => {
 
 // make html head row - th
 const toHeadRow = (options) => {
-  const lastTd = options.hasMissing ? '<th>Missing</th>' : '';
+  const branchTh = options.hasBranch ? '<th>Branch</th><th>BrPart</th>' : '';
+  const missingTh = options.hasMissing ? '<th>Missing</th>' : '';
 
-  return `<tr><th>File</th><th>Stmts</th><th>Miss</th><th>Cover</th>${lastTd}</tr>`;
+  // prettier-ignore
+  return `<tr><th>File</th><th>Stmts</th><th>Miss</th>${branchTh}<th>Cover</th>${missingTh}</tr>`;
 };
 
 // make html row - tr
@@ -38556,17 +38586,26 @@ const toRow = (item, indent = false, options) => {
 
   const name = toFileNameTd(item, indent, options);
   const missing = toMissingTd(item, options);
-  const lastTd = options.hasMissing ? `<td>${missing}</td>` : '';
+  const branchTd = options.hasBranch
+    ? `<td>${item.branch || 0}</td><td>${item.brpart || 0}</td>`
+    : '';
+  const missingTd = options.hasMissing ? `<td>${missing}</td>` : '';
 
-  return `<tr><td>${name}</td><td>${stmts}</td><td>${miss}</td><td>${cover}</td>${lastTd}</tr>`;
+  // prettier-ignore
+  return `<tr><td>${name}</td><td>${stmts}</td><td>${miss}</td>${branchTd}<td>${cover}</td>${missingTd}</tr>`;
 };
 
 // make summary row - tr
 const toTotalRow = (item, options) => {
   const { name, stmts, miss, cover } = item;
-  const emptyCell = options.hasMissing ? '<td>&nbsp;</td>' : '';
+  const branchTd = options.hasBranch
+    ? `<td><b>${item.branch || 0}</b></td>` +
+      `<td><b>${item.brpart || 0}</b></td>`
+    : '';
+  const missingTd = options.hasMissing ? '<td>&nbsp;</td>' : '';
 
-  return `<tr><td><b>${name}</b></td><td><b>${stmts}</b></td><td><b>${miss}</b></td><td><b>${cover}</b></td>${emptyCell}</tr>`;
+  // prettier-ignore
+  return `<tr><td><b>${name}</b></td><td><b>${stmts}</b></td><td><b>${miss}</b></td>${branchTd}<td><b>${cover}</b></td>${missingTd}</tr>`;
 };
 
 // make fileName cell - td
@@ -38589,7 +38628,8 @@ const toFolderTd = (path, options) => {
     return '';
   }
 
-  const colspan = options.hasMissing ? 5 : 4;
+  const colspan =
+    4 + (options.hasBranch ? 2 : 0) + (options.hasMissing ? 1 : 0);
   return `<tr><td colspan="${colspan}"><b>${path}</b></td></tr>`;
 };
 
@@ -38647,13 +38687,22 @@ const getTotalCoverage = (parsedXml) => {
   const cover = parseInt(parseFloat(coverage['line-rate']) * 100);
   const linesValid = parseInt(coverage['lines-valid']);
   const linesCovered = parseInt(coverage['lines-covered']);
+  const branchesValid = parseInt(coverage['branches-valid']) || 0;
+  const branchesCovered = parseInt(coverage['branches-covered']) || 0;
 
-  return {
+  const result = {
     name: 'TOTAL',
     stmts: linesValid,
     miss: linesValid - linesCovered,
     cover: cover !== '0' ? `${cover}%` : '0',
   };
+
+  if (branchesValid > 0) {
+    result.branch = branchesValid;
+    result.brpart = branchesValid - branchesCovered;
+  }
+
+  return result;
 };
 
 // return true if "coverage file" include right structure
@@ -38750,7 +38799,13 @@ const parseClass = (classObj, xmlSkipCovered) => {
     return null;
   }
 
-  const { stmts, missing, totalMissing: miss } = parseLines(classObj.lines);
+  const {
+    stmts,
+    missing,
+    totalMissing: miss,
+    branchTotal,
+    branchMissing,
+  } = parseLines(classObj.lines);
   const { filename: name, 'line-rate': lineRate } = classObj['$'];
   const isFullCoverage = lineRate === '1';
 
@@ -38762,23 +38817,56 @@ const parseClass = (classObj, xmlSkipCovered) => {
     ? '100%'
     : `${parseInt(parseFloat(lineRate) * 100)}%`;
 
-  return { name, stmts, miss, cover, missing };
+  const result = { name, stmts, miss, cover, missing };
+
+  if (branchTotal > 0) {
+    result.branch = branchTotal.toString();
+    result.brpart = branchMissing.toString();
+  }
+
+  return result;
 };
 
 const parseLines = (lines) => {
+  const emptyResult = {
+    stmts: '0',
+    missing: '',
+    totalMissing: '0',
+    branchTotal: 0,
+    branchMissing: 0,
+  };
+
   if (!lines || !lines.length || !lines[0].line) {
-    return { stmts: '0', missing: '', totalMissing: '0' };
+    return emptyResult;
   }
 
   let stmts = 0;
   const missingLines = [];
+  let branchTotal = 0;
+  let branchMissing = 0;
 
   lines[0].line.forEach((line) => {
     stmts++;
-    const { hits, number } = line['$'];
+    const {
+      hits,
+      number,
+      branch,
+      'condition-coverage': condCoverage,
+    } = line['$'];
 
     if (hits === '0') {
       missingLines.push(parseInt(number));
+    }
+
+    if (branch === 'true' && condCoverage) {
+      const match = condCoverage.match(/\((\d+)\/(\d+)\)/);
+
+      if (match) {
+        const covered = parseInt(match[1]);
+        const total = parseInt(match[2]);
+        branchTotal += total;
+        branchMissing += total - covered;
+      }
     }
   });
 
@@ -38801,6 +38889,8 @@ const parseLines = (lines) => {
     stmts: stmts.toString(),
     missing: missingText,
     totalMissing: missingLines.length.toString(),
+    branchTotal,
+    branchMissing,
   };
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pytest-coverage-comment",
-  "version": "1.2.1",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pytest-coverage-comment",
-      "version": "1.2.1",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pytest-coverage-comment",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Comments a pull request with the pytest code coverage badge, full report and tests summary",
   "author": "Misha Kav",
   "license": "MIT",

--- a/src/cli.js
+++ b/src/cli.js
@@ -36,7 +36,7 @@ const getPathToFile = (pathToFile) => {
 const main = async () => {
   const covFile = './../data/pytest-coverage_4.txt';
   const xmlFile = './../data/pytest_1.xml';
-  const covXmlFile = './../data/coverage_1.xml';
+  const covXmlFile = './../data/coverage_1.xml'; // use coverage_2.xml for branch coverage
   const prefix = path.dirname(path.dirname(path.resolve(covFile))) + '/';
   // eslint-disable-next-line
   const multipleFiles = [

--- a/src/parse.js
+++ b/src/parse.js
@@ -18,6 +18,15 @@ const isValidCoverageContent = (data) => {
   return wordsToInclude.every((w) => data.includes(w));
 };
 
+// return true if coverage data includes branch coverage columns
+const hasBranchCoverage = (data) => {
+  if (!data || !data.length) {
+    return false;
+  }
+
+  return data.includes('Branch') && data.includes('BrPart');
+};
+
 // return full html coverage report and coverage percentage
 const getCoverageReport = (options) => {
   const { covFile, covXmlFile } = options;
@@ -79,8 +88,9 @@ const getTotal = (data) => {
 
   const lines = data.split('\n');
   const line = lines.find((l) => l.includes('TOTAL    '));
+  const hasBranch = hasBranchCoverage(data);
 
-  return parseTotalLine(line);
+  return parseTotalLine(line, hasBranch);
 };
 
 // get number of warnings from coverage-file
@@ -102,14 +112,15 @@ const getWarnings = (data) => {
 };
 
 // parse one line from coverage-file
-const parseOneLine = (line) => {
+const parseOneLine = (line, hasBranch = false) => {
   if (!line) {
     return null;
   }
 
   const parsedLine = line.split('   ').filter((l) => l);
+  const minCols = hasBranch ? 6 : 4;
 
-  if (parsedLine.length < 4) {
+  if (parsedLine.length < minCols) {
     return null;
   }
 
@@ -123,17 +134,24 @@ const parseOneLine = (line) => {
     : parsedLine[parsedLine.length - 1] &&
       parsedLine[parsedLine.length - 1].split(', ');
 
-  return {
+  const result = {
     name: parsedLine[0],
     stmts: parsedLine[1].trim(),
     miss: parsedLine[2].trim(),
     cover,
     missing,
   };
+
+  if (hasBranch) {
+    result.branch = parsedLine[3].trim();
+    result.brpart = parsedLine[4].trim();
+  }
+
+  return result;
 };
 
 // parse total line from coverage-file
-const parseTotalLine = (line) => {
+const parseTotalLine = (line, hasBranch = false) => {
   if (!line) {
     return null;
   }
@@ -144,12 +162,19 @@ const parseTotalLine = (line) => {
     return null;
   }
 
-  return {
+  const result = {
     name: parsedLine[0],
     stmts: parsedLine[1].trim(),
     miss: parsedLine[2].trim(),
     cover: parsedLine[parsedLine.length - 1].trim(),
   };
+
+  if (hasBranch) {
+    result.branch = parsedLine[3].trim();
+    result.brpart = parsedLine[4].trim();
+  }
+
+  return result;
 };
 
 // parse coverage-file
@@ -160,7 +185,9 @@ const parse = (data) => {
     return null;
   }
 
-  return actualLines.map(parseOneLine);
+  const hasBranch = hasBranchCoverage(data);
+
+  return actualLines.map((line) => parseOneLine(line, hasBranch));
 };
 
 // collapse all lines to folders structure
@@ -227,6 +254,7 @@ const toTable = (data, options, dataFromXml = null) => {
   }
   const totalLine = dataFromXml ? dataFromXml.total : getTotal(data);
   options.hasMissing = coverage.some((c) => c.missing);
+  options.hasBranch = coverage.some((c) => c.branch !== undefined);
 
   core.info(`Generating coverage report`);
   const headTr = toHeadRow(options);
@@ -273,9 +301,11 @@ const toTable = (data, options, dataFromXml = null) => {
 
 // make html head row - th
 const toHeadRow = (options) => {
-  const lastTd = options.hasMissing ? '<th>Missing</th>' : '';
+  const branchTh = options.hasBranch ? '<th>Branch</th><th>BrPart</th>' : '';
+  const missingTh = options.hasMissing ? '<th>Missing</th>' : '';
 
-  return `<tr><th>File</th><th>Stmts</th><th>Miss</th><th>Cover</th>${lastTd}</tr>`;
+  // prettier-ignore
+  return `<tr><th>File</th><th>Stmts</th><th>Miss</th>${branchTh}<th>Cover</th>${missingTh}</tr>`;
 };
 
 // make html row - tr
@@ -284,17 +314,26 @@ const toRow = (item, indent = false, options) => {
 
   const name = toFileNameTd(item, indent, options);
   const missing = toMissingTd(item, options);
-  const lastTd = options.hasMissing ? `<td>${missing}</td>` : '';
+  const branchTd = options.hasBranch
+    ? `<td>${item.branch || 0}</td><td>${item.brpart || 0}</td>`
+    : '';
+  const missingTd = options.hasMissing ? `<td>${missing}</td>` : '';
 
-  return `<tr><td>${name}</td><td>${stmts}</td><td>${miss}</td><td>${cover}</td>${lastTd}</tr>`;
+  // prettier-ignore
+  return `<tr><td>${name}</td><td>${stmts}</td><td>${miss}</td>${branchTd}<td>${cover}</td>${missingTd}</tr>`;
 };
 
 // make summary row - tr
 const toTotalRow = (item, options) => {
   const { name, stmts, miss, cover } = item;
-  const emptyCell = options.hasMissing ? '<td>&nbsp;</td>' : '';
+  const branchTd = options.hasBranch
+    ? `<td><b>${item.branch || 0}</b></td>` +
+      `<td><b>${item.brpart || 0}</b></td>`
+    : '';
+  const missingTd = options.hasMissing ? '<td>&nbsp;</td>' : '';
 
-  return `<tr><td><b>${name}</b></td><td><b>${stmts}</b></td><td><b>${miss}</b></td><td><b>${cover}</b></td>${emptyCell}</tr>`;
+  // prettier-ignore
+  return `<tr><td><b>${name}</b></td><td><b>${stmts}</b></td><td><b>${miss}</b></td>${branchTd}<td><b>${cover}</b></td>${missingTd}</tr>`;
 };
 
 // make fileName cell - td
@@ -317,7 +356,8 @@ const toFolderTd = (path, options) => {
     return '';
   }
 
-  const colspan = options.hasMissing ? 5 : 4;
+  const colspan =
+    4 + (options.hasBranch ? 2 : 0) + (options.hasMissing ? 1 : 0);
   return `<tr><td colspan="${colspan}"><b>${path}</b></td></tr>`;
 };
 

--- a/src/parse.js
+++ b/src/parse.js
@@ -157,8 +157,9 @@ const parseTotalLine = (line, hasBranch = false) => {
   }
 
   const parsedLine = line.split('  ').filter((l) => l);
+  const minCols = hasBranch ? 6 : 4;
 
-  if (parsedLine.length < 4) {
+  if (parsedLine.length < minCols) {
     return null;
   }
 

--- a/src/parseXml.js
+++ b/src/parseXml.js
@@ -34,8 +34,8 @@ const getTotalCoverage = (parsedXml) => {
   };
 
   if (branchesValid > 0) {
-    result.branch = branchesValid;
-    result.brpart = branchesValid - branchesCovered;
+    result.branch = branchesValid.toString();
+    result.brpart = (branchesValid - branchesCovered).toString();
   }
 
   return result;

--- a/src/parseXml.js
+++ b/src/parseXml.js
@@ -23,13 +23,22 @@ const getTotalCoverage = (parsedXml) => {
   const cover = parseInt(parseFloat(coverage['line-rate']) * 100);
   const linesValid = parseInt(coverage['lines-valid']);
   const linesCovered = parseInt(coverage['lines-covered']);
+  const branchesValid = parseInt(coverage['branches-valid']) || 0;
+  const branchesCovered = parseInt(coverage['branches-covered']) || 0;
 
-  return {
+  const result = {
     name: 'TOTAL',
     stmts: linesValid,
     miss: linesValid - linesCovered,
     cover: cover !== '0' ? `${cover}%` : '0',
   };
+
+  if (branchesValid > 0) {
+    result.branch = branchesValid;
+    result.brpart = branchesValid - branchesCovered;
+  }
+
+  return result;
 };
 
 // return true if "coverage file" include right structure
@@ -126,7 +135,13 @@ const parseClass = (classObj, xmlSkipCovered) => {
     return null;
   }
 
-  const { stmts, missing, totalMissing: miss } = parseLines(classObj.lines);
+  const {
+    stmts,
+    missing,
+    totalMissing: miss,
+    branchTotal,
+    branchMissing,
+  } = parseLines(classObj.lines);
   const { filename: name, 'line-rate': lineRate } = classObj['$'];
   const isFullCoverage = lineRate === '1';
 
@@ -138,23 +153,56 @@ const parseClass = (classObj, xmlSkipCovered) => {
     ? '100%'
     : `${parseInt(parseFloat(lineRate) * 100)}%`;
 
-  return { name, stmts, miss, cover, missing };
+  const result = { name, stmts, miss, cover, missing };
+
+  if (branchTotal > 0) {
+    result.branch = branchTotal.toString();
+    result.brpart = branchMissing.toString();
+  }
+
+  return result;
 };
 
 const parseLines = (lines) => {
+  const emptyResult = {
+    stmts: '0',
+    missing: '',
+    totalMissing: '0',
+    branchTotal: 0,
+    branchMissing: 0,
+  };
+
   if (!lines || !lines.length || !lines[0].line) {
-    return { stmts: '0', missing: '', totalMissing: '0' };
+    return emptyResult;
   }
 
   let stmts = 0;
   const missingLines = [];
+  let branchTotal = 0;
+  let branchMissing = 0;
 
   lines[0].line.forEach((line) => {
     stmts++;
-    const { hits, number } = line['$'];
+    const {
+      hits,
+      number,
+      branch,
+      'condition-coverage': condCoverage,
+    } = line['$'];
 
     if (hits === '0') {
       missingLines.push(parseInt(number));
+    }
+
+    if (branch === 'true' && condCoverage) {
+      const match = condCoverage.match(/\((\d+)\/(\d+)\)/);
+
+      if (match) {
+        const covered = parseInt(match[1]);
+        const total = parseInt(match[2]);
+        branchTotal += total;
+        branchMissing += total - covered;
+      }
     }
   });
 
@@ -177,6 +225,8 @@ const parseLines = (lines) => {
     stmts: stmts.toString(),
     missing: missingText,
     totalMissing: missingLines.length.toString(),
+    branchTotal,
+    branchMissing,
   };
 };
 


### PR DESCRIPTION
## Summary

- Auto-detect and display `Branch` / `BrPart` columns in the coverage table when branch data is present
- Supported for both text format (`pytest --cov --cov-branch`) and XML format (`coverage.xml`)
- No new action inputs required — columns appear automatically, fully backward compatible

Without branch coverage (unchanged):
```
| File | Stmts | Miss | Cover | Missing |
```

With branch coverage (auto-detected):
```
| File | Stmts | Miss | Branch | BrPart | Cover | Missing |
```

Closes #110

## Test plan

- [x] Text parsing with branch data (`pytest-coverage_11.txt`)
- [x] XML parsing with branch data (`coverage_2.xml`)
- [x] Backward compat — text without branches (`pytest-coverage_4.txt`)
- [x] Backward compat — XML without branches (`coverage_1.xml`)
- [x] Existing test passes (`node test/multiple-files.test.js`)
- [x] Lint clean, build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)