### PR TITLE
Add hide-emoji option to disable emojis in summary table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog of the Pytest Coverage Comment
 
+## [Pytest Coverage Comment 1.5.0](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.5.0)
+
+**Release Date:** 2026-02-28
+
+#### Changes
+
+- feat: add `hide-emoji` option to hide emoji shortcodes from the test summary table (#251)
+- docs: update README examples to use `@v1` tag and latest action versions (`checkout@v6`, `setup-python@v6`)
+
 ## [Pytest Coverage Comment 1.4.0](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.4.0)
 
 **Release Date:** 2026-02-22

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Add this action to your workflow:
 
 ```yaml
 - name: Pytest coverage comment
-  uses: MishaKav/pytest-coverage-comment@main
+  uses: MishaKav/pytest-coverage-comment@v1
   with:
     pytest-coverage-path: ./pytest-coverage.txt
     junitxml-path: ./pytest.xml
@@ -115,10 +115,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.11
 
@@ -131,7 +131,7 @@ jobs:
           pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=src tests/ | tee pytest-coverage.txt
 
       - name: Pytest coverage comment
-        uses: MishaKav/pytest-coverage-comment@main
+        uses: MishaKav/pytest-coverage-comment@v1
         with:
           pytest-coverage-path: ./pytest-coverage.txt
           junitxml-path: ./pytest.xml
@@ -167,6 +167,7 @@ jobs:
 | `hide-badge`                | `false`           | Hide the coverage percentage badge from the comment                 |
 | `hide-report`               | `false`           | Hide the detailed coverage table (show only summary and badge)      |
 | `hide-comment`              | `false`           | Skip creating PR comment entirely (useful for using outputs only)   |
+| `hide-emoji`                | `false`           | Hide emojis from the test summary table                             |
 | `report-only-changed-files` | `false`           | Show only files changed in the current pull request                 |
 | `xml-skip-covered`          | `false`           | Hide files with 100% coverage from XML coverage reports             |
 | `remove-link-from-badge`    | `false`           | Remove hyperlink from coverage badge (badge becomes plain image)    |
@@ -223,7 +224,7 @@ jobs:
     pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=src tests/ | tee pytest-coverage.txt
 
 - name: Coverage comment
-  uses: MishaKav/pytest-coverage-comment@main
+  uses: MishaKav/pytest-coverage-comment@v1
   with:
     pytest-coverage-path: ./pytest-coverage.txt
     junitxml-path: ./pytest.xml
@@ -242,7 +243,7 @@ jobs:
     pytest --cov-report=xml:coverage.xml --cov=src tests/
 
 - name: Coverage comment
-  uses: MishaKav/pytest-coverage-comment@main
+  uses: MishaKav/pytest-coverage-comment@v1
   with:
     pytest-xml-coverage-path: ./coverage.xml
     junitxml-path: ./pytest.xml
@@ -257,7 +258,7 @@ jobs:
 
 ```yaml
 - name: Coverage comment
-  uses: MishaKav/pytest-coverage-comment@main
+  uses: MishaKav/pytest-coverage-comment@v1
   with:
     multiple-files: |
       Backend API, ./backend/pytest-coverage.txt, ./backend/pytest.xml
@@ -279,6 +280,32 @@ This creates a consolidated table showing all coverage reports:
 
 </details>
 
+### Clean Summary Without Emojis
+
+<details>
+<summary>Hide emojis for a cleaner appearance</summary>
+
+```yaml
+- name: Coverage comment
+  uses: MishaKav/pytest-coverage-comment@v1
+  with:
+    pytest-coverage-path: ./pytest-coverage.txt
+    junitxml-path: ./pytest.xml
+    hide-emoji: true
+```
+
+**Default behavior** (with emojis):
+| Tests | Skipped | Failures | Errors | Time |
+| ----- | ------- | -------- | ------ | ---- |
+| 109   | 2 :zzz: | 1 :x:    | 0 :fire: | 0.583s :stopwatch: |
+
+**With `hide-emoji: true`**:
+| Tests | Skipped | Failures | Errors | Time |
+| ----- | ------- | -------- | ------ | ---- |
+| 109   | 2       | 1        | 0      | 0.583s |
+
+</details>
+
 ### Docker Workflows
 
 <details>
@@ -294,7 +321,7 @@ This creates a consolidated table showing all coverage reports:
         --cov=src tests/ | tee /tmp/pytest-coverage.txt
 
 - name: Coverage comment
-  uses: MishaKav/pytest-coverage-comment@main
+  uses: MishaKav/pytest-coverage-comment@v1
   with:
     pytest-coverage-path: /tmp/pytest-coverage.txt
     junitxml-path: /tmp/pytest.xml
@@ -315,7 +342,7 @@ strategy:
 
 steps:
   - name: Coverage comment
-    uses: MishaKav/pytest-coverage-comment@main
+    uses: MishaKav/pytest-coverage-comment@v1
     with:
       pytest-coverage-path: ./pytest-coverage.txt
       junitxml-path: ./pytest.xml
@@ -352,7 +379,7 @@ jobs:
   update-badge:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -363,7 +390,7 @@ jobs:
 
       - name: Coverage comment
         id: coverage
-        uses: MishaKav/pytest-coverage-comment@main
+        uses: MishaKav/pytest-coverage-comment@v1
         with:
           pytest-coverage-path: ./pytest-coverage.txt
           junitxml-path: ./pytest.xml
@@ -399,7 +426,7 @@ Here's what the generated coverage comment looks like:
 
 ```yaml
 - name: Coverage comment
-  uses: MishaKav/pytest-coverage-comment@main
+  uses: MishaKav/pytest-coverage-comment@v1
   with:
     pytest-coverage-path: ./pytest-coverage.txt
     junitxml-path: ./pytest.xml
@@ -416,7 +443,7 @@ Displays coverage as `85% (42/50)` instead of a badge image.
 ```yaml
 - name: Coverage comment
   id: coverage
-  uses: MishaKav/pytest-coverage-comment@main
+  uses: MishaKav/pytest-coverage-comment@v1
   with:
     pytest-coverage-path: ./pytest-coverage.txt
     junitxml-path: ./pytest.xml
@@ -445,7 +472,7 @@ Displays coverage as `85% (42/50)` instead of a badge image.
 
 ```yaml
 - name: Coverage comment (changed files only)
-  uses: MishaKav/pytest-coverage-comment@main
+  uses: MishaKav/pytest-coverage-comment@v1
   with:
     pytest-coverage-path: ./pytest-coverage.txt
     junitxml-path: ./pytest.xml
@@ -473,7 +500,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Coverage comment
-        uses: MishaKav/pytest-coverage-comment@main
+        uses: MishaKav/pytest-coverage-comment@v1
         with:
           pytest-coverage-path: ./pytest-coverage.txt
           junitxml-path: ./pytest.xml
@@ -489,7 +516,7 @@ For large coverage reports that might exceed GitHub's comment size limits:
 
 ```yaml
 - name: Coverage comment
-  uses: MishaKav/pytest-coverage-comment@main
+  uses: MishaKav/pytest-coverage-comment@v1
   with:
     pytest-coverage-path: ./pytest-coverage.txt
     junitxml-path: ./pytest.xml

--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,11 @@ inputs:
     default: 'false'
     required: false
 
+  hide-emoji:
+    description: 'Hide emojis in the test summary table (skipped/failures/errors/time columns)'
+    default: 'false'
+    required: false
+
   xml-skip-covered:
     description: 'Hide files with 100% coverage from XML coverage reports'
     default: 'false'

--- a/dist/index.js
+++ b/dist/index.js
@@ -38118,9 +38118,10 @@ const toMarkdown = (summary, options) => {
     time > 60
       ? `${(time / 60) | 0}m ${(time % 60) | 0}s`
       : `${time.toFixed(3)}s`;
+  const e = (emoji) => (options.hideEmoji ? '' : ` ${emoji}`);
   const table = `| Tests | Skipped | Failures | Errors | Time |
 | ----- | ------- | -------- | -------- | ------------------ |
-| ${tests} | ${skipped} :zzz: | ${failures} :x: | ${errors} :fire: | ${displayTime} :stopwatch: |
+| ${tests} | ${skipped}${e(':zzz:')} | ${failures}${e(':x:')} | ${errors}${e(':fire:')} | ${displayTime}${e(':stopwatch:')} |
 `;
 
   if (options.xmlTitle) {
@@ -38246,7 +38247,8 @@ const getMultipleReport = (options) => {
         const { errors, failures, skipped, tests, time } = summary;
         const displayTime =
           time > 60 ? `${(time / 60) | 0}m ${(time % 60) | 0}s` : `${time}s`;
-        table += `| ${tests} | ${skipped} :zzz: | ${failures} :x: | ${errors} :fire: | ${displayTime} :stopwatch: |
+        const e = (emoji) => (options.hideEmoji ? '' : ` ${emoji}`);
+        table += `| ${tests} | ${skipped}${e(':zzz:')} | ${failures}${e(':x:')} | ${errors}${e(':fire:')} | ${displayTime}${e(':stopwatch:')} |
 `;
       } else {
         table += `
@@ -43842,6 +43844,7 @@ const main = async () => {
     required: false,
   });
   const hideComment = core.getBooleanInput('hide-comment', { required: false });
+  const hideEmoji = core.getBooleanInput('hide-emoji', { required: false });
   const xmlSkipCovered = core.getBooleanInput('xml-skip-covered', {
     required: false,
   });
@@ -43902,6 +43905,7 @@ const main = async () => {
     hideReport,
     createNewComment,
     hideComment,
+    hideEmoji,
     xmlSkipCovered,
     reportOnlyChangedFiles,
     removeLinkFromBadge,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pytest-coverage-comment",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pytest-coverage-comment",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pytest-coverage-comment",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Comments a pull request with the pytest code coverage badge, full report and tests summary",
   "author": "Misha Kav",
   "license": "MIT",

--- a/src/cli.js
+++ b/src/cli.js
@@ -67,6 +67,7 @@ const main = async () => {
     reportOnlyChangedFiles: false,
     removeLinkFromBadge: false,
     hideComment: false,
+    hideEmoji: false,
     xmlSkipCovered: false,
     xmlTitle: '',
     // multipleFiles,

--- a/src/index.js
+++ b/src/index.js
@@ -192,6 +192,7 @@ const main = async () => {
     required: false,
   });
   const hideComment = core.getBooleanInput('hide-comment', { required: false });
+  const hideEmoji = core.getBooleanInput('hide-emoji', { required: false });
   const xmlSkipCovered = core.getBooleanInput('xml-skip-covered', {
     required: false,
   });
@@ -252,6 +253,7 @@ const main = async () => {
     hideReport,
     createNewComment,
     hideComment,
+    hideEmoji,
     xmlSkipCovered,
     reportOnlyChangedFiles,
     removeLinkFromBadge,

--- a/src/junitXml.js
+++ b/src/junitXml.js
@@ -111,9 +111,10 @@ const toMarkdown = (summary, options) => {
     time > 60
       ? `${(time / 60) | 0}m ${(time % 60) | 0}s`
       : `${time.toFixed(3)}s`;
+  const e = (emoji) => (options.hideEmoji ? '' : ` ${emoji}`);
   const table = `| Tests | Skipped | Failures | Errors | Time |
 | ----- | ------- | -------- | -------- | ------------------ |
-| ${tests} | ${skipped} :zzz: | ${failures} :x: | ${errors} :fire: | ${displayTime} :stopwatch: |
+| ${tests} | ${skipped}${e(':zzz:')} | ${failures}${e(':x:')} | ${errors}${e(':fire:')} | ${displayTime}${e(':stopwatch:')} |
 `;
 
   if (options.xmlTitle) {

--- a/src/multiFiles.js
+++ b/src/multiFiles.js
@@ -105,7 +105,8 @@ const getMultipleReport = (options) => {
         const { errors, failures, skipped, tests, time } = summary;
         const displayTime =
           time > 60 ? `${(time / 60) | 0}m ${(time % 60) | 0}s` : `${time}s`;
-        table += `| ${tests} | ${skipped} :zzz: | ${failures} :x: | ${errors} :fire: | ${displayTime} :stopwatch: |
+        const e = (emoji) => (options.hideEmoji ? '' : ` ${emoji}`);
+        table += `| ${tests} | ${skipped}${e(':zzz:')} | ${failures}${e(':x:')} | ${errors}${e(':fire:')} | ${displayTime}${e(':stopwatch:')} |
 `;
       } else {
         table += `


### PR DESCRIPTION
## Summary
- Add `hide-emoji` input to remove emoji shortcodes (`:zzz:`, `:x:`, `:fire:`, `:stopwatch:`) from test summary tables
- Update README examples to use `@v1` tag and latest action versions (`checkout@v6`, `setup-python@v6`)
- Bump version to 1.5.0

## Test plan
- [ ] Run `npm run all` — lint, format, build pass
- [ ] Test with `hide-emoji: true` — emojis removed from summary table
- [ ] Test with `hide-emoji: false` (default) — emojis present as before
- [ ] Verify `multiple-files` mode also respects the flag

Fixes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional hide-emoji input to remove emoji shortcodes from the test summary table. Updates README examples to use @v1 and latest GitHub Actions; bumps the action to 1.5.0.

- **New Features**
  - New input hide-emoji (default false) to hide :zzz:, :x:, :fire:, :stopwatch: in the summary table.
  - Works in both single-report and multiple-files modes and is exposed in the CLI.
  - No change to default behavior.

<sup>Written for commit 0f37795e83f6aa7da8d4c323debdec4cfd16522d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

