### PR TITLE
Enable immutable releases for supply chain security (#256)

### DIFF
--- a/.github/workflows/publish-immutable-actions.yml
+++ b/.github/workflows/publish-immutable-actions.yml
@@ -1,0 +1,16 @@
+name: Publish Immutable Action Version
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/publish-immutable-action@v0.0.4

--- a/.github/workflows/update-main-version.yml
+++ b/.github/workflows/update-main-version.yml
@@ -1,0 +1,29 @@
+name: Update Main Version
+run-name: Move ${{ github.event.inputs.major_version }} to ${{ github.event.inputs.target }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: The tag or reference to use
+        required: true
+      major_version:
+        type: choice
+        description: The major version to update
+        options:
+          - v1
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Tag new target
+        run: git tag -f ${{ github.event.inputs.major_version }} ${{ github.event.inputs.target }}
+
+      - name: Push new tag
+        run: git push origin ${{ github.event.inputs.major_version }} --force

--- a/.github/workflows/update-main-version.yml
+++ b/.github/workflows/update-main-version.yml
@@ -1,5 +1,5 @@
 name: Update Main Version
-run-name: Move ${{ github.event.inputs.major_version }} to ${{ github.event.inputs.target }}
+run-name: Move ${{ inputs.major_version }} to ${{ inputs.target }}
 
 on:
   workflow_dispatch:
@@ -22,8 +22,14 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
       - name: Tag new target
-        run: git tag -f ${{ github.event.inputs.major_version }} ${{ github.event.inputs.target }}
+        env:
+          MAJOR_VERSION: ${{ inputs.major_version }}
+          TARGET: ${{ inputs.target }}
+        run: git tag -f "$MAJOR_VERSION" "$TARGET"
 
       - name: Push new tag
-        run: git push origin ${{ github.event.inputs.major_version }} --force
+        env:
+          MAJOR_VERSION: ${{ inputs.major_version }}
+        run: git push origin "$MAJOR_VERSION" --force

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog of the Pytest Coverage Comment
 
+## [Pytest Coverage Comment 1.7.0](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.7.0)
+
+**Release Date:** 2026-03-13
+
+#### Changes
+
+- enable immutable releases for supply chain security (#256)
+- bump `flatted` from 3.3.3 to 3.4.1 to fix security vulnerability
+
+**Note:** No changes to action inputs, outputs, or behavior. This improves release security following [GitHub's immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases) feature.
+
 ## [Pytest Coverage Comment 1.6.0](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.6.0)
 
 **Release Date:** 2026-03-06

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pytest-coverage-comment",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pytest-coverage-comment",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^2.0.3",
@@ -984,9 +984,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1001,9 +998,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1018,9 +1012,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1035,9 +1026,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1052,9 +1040,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1069,9 +1054,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1086,9 +1068,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1103,9 +1082,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1120,9 +1096,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1137,9 +1110,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1154,9 +1124,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1171,9 +1138,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1188,9 +1152,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2203,9 +2164,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
       "dev": true,
       "license": "ISC"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pytest-coverage-comment",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Comments a pull request with the pytest code coverage badge, full report and tests summary",
   "author": "Misha Kav",
   "license": "MIT",
@@ -29,7 +29,6 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "bump-version": "npm version patch",
-    "update-v1-tag": "git tag v1 -f && git push origin v1 -f",
     "all": "npm run typecheck && npm run lint && npm run format && npm run test && npm run build"
   },
   "dependencies": {


### PR DESCRIPTION
## **User description**
## Summary

- Add `publish-immutable-actions` workflow to publish immutable OCI packages to GHCR on release
- Add `update-main-version` workflow to automate force-pushing the `v1` major version tag
- Remove `update-v1-tag` script from `package.json` (replaced by workflow)
- Bump `flatted` from 3.3.3 to 3.4.1 (`npm audit fix`)
- Bump version to 1.7.0

## Test plan

- [ ] Verify `publish-immutable-actions.yml` triggers on release publish
- [ ] Verify `update-main-version.yml` is available via workflow_dispatch
- [ ] Confirm `MishaKav/pytest-coverage-comment@v1` still resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes immutable action releases to GHCR and automates `v1` tag updates to improve supply chain security. No behavior changes; version bumped to 1.7.0.

- **New Features**
  - Add release workflow to push immutable OCI packages to GHCR using `actions/publish-immutable-action@v0.0.4`.
  - Add manual workflow to move the `v1` tag; harden inputs by restricting `major_version` to `v1` and requiring a `target`; remove the `update-v1-tag` script.

- **Dependencies**
  - Bump `flatted` to `3.4.1` (security fix).

<sup>Written for commit bbe4d2056fca2de077cac082805ad7c0e8cbd8b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Enable immutable releases to GHCR and add a manual workflow to move the v1 tag

### What Changed
- On release publish, the action now publishes an immutable OCI package to GitHub Container Registry so released action versions are immutable
- Added a manual workflow to move the repository's v1 tag to a specified target (workflow requires a target and only allows updating v1)
- Removed the local script that force-updated v1; tag updates are intended to be done via the new workflow
- Bumped package version to 1.7.0 and upgraded flatted to 3.4.1 to address a security vulnerability
- Changelog updated to record the immutable-release and dependency changes

### Impact
`✅ Immutable releases published to GHCR`
`✅ Easier, auditable v1 tag updates via workflow`
`✅ Fixes known flatted security vulnerability`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
