### PR TITLE
fix: include covered branches when calculating coverage percentage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog of the Pytest Coverage Comment
 
+## Unreleased
+
+### Fixes
+
+- Show the correct Coverage percentage when using branch coverage to match what `coverage report` shows
+
 ## [Pytest Coverage Comment 1.8.0](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.8.0)
 
 **Release Date:** 2026-06-27

--- a/__tests__/parseXml.test.ts
+++ b/__tests__/parseXml.test.ts
@@ -84,6 +84,20 @@ describe('getCoverageXmlReport', () => {
     expect(result!.html).toContain('>63->66</a>');
   });
 
+  test('should include partial branches in the cover percentage, not just statement coverage', () => {
+    const covXmlFile = path.join(dataPath, 'coverage_3.xml');
+    const options = { ...baseOptions, covXmlFile };
+    const result = getCoverageXmlReport(options);
+
+    expect(result).not.toBeNull();
+    // foo.py has 0 missing statements (line-rate="1") but 2 of its 4 branches
+    // are uncovered, so `coverage report` shows 83%, not 100%. The file row
+    // and the TOTAL row should match that, the same as `coverage report`.
+    expect(result!.coverage!.cover).toBe('83%');
+    expect(result!.html).not.toContain('100%');
+    expect(result!.html).toContain('<td>83%</td>');
+  });
+
   test('should combine partial branches and show exit in arrows', () => {
     const covXmlFile = path.join(dataPath, 'coverage_3.xml');
     const options = { ...baseOptions, covXmlFile };

--- a/dist/index.js
+++ b/dist/index.js
@@ -39918,16 +39918,27 @@ const getParsedXml = (options) => {
     }
     return null;
 };
+// Combine statement and branch coverage into a single percentage, the same
+// way coverage.py's own `coverage report` does:
+// (executed statements + executed branches) / (total statements + total branches).
+// Cobertura tracks `line-rate` and `branch-rate` independently, so a file
+// with every statement executed but a partially-covered branch reports
+// line-rate="1" even though `coverage report` shows less than 100%.
+const computeCoverPercent = (coveredStmts, totalStmts, coveredBranches, totalBranches) => {
+    const numerator = coveredStmts + coveredBranches;
+    const denominator = totalStmts + totalBranches;
+    return denominator > 0 ? (numerator / denominator) * 100 : 100;
+};
 const getTotalCoverage = (parsedXml) => {
     if (!parsedXml) {
         return null;
     }
     const coverage = parsedXml['$'];
-    const cover = parseInt(String(parseFloat(coverage['line-rate']) * 100));
     const linesValid = parseInt(coverage['lines-valid']);
     const linesCovered = parseInt(coverage['lines-covered']);
     const branchesValid = parseInt(coverage['branches-valid']) || 0;
     const branchesCovered = parseInt(coverage['branches-covered']) || 0;
+    const cover = parseInt(String(computeCoverPercent(linesCovered, linesValid, branchesCovered, branchesValid)));
     const result = {
         name: 'TOTAL',
         stmts: linesValid,
@@ -40029,14 +40040,15 @@ const parseClass = (classObj, xmlSkipCovered) => {
         return null;
     }
     const { stmts, missing, totalMissing: miss, branchTotal, branchMissing, } = parseLines(classObj.lines);
-    const { filename: name, 'line-rate': lineRate } = classObj['$'];
-    const isFullCoverage = lineRate === '1';
+    const { filename: name } = classObj['$'];
+    const stmtsTotal = parseInt(stmts, 10);
+    const stmtsMissing = parseInt(miss, 10);
+    const isFullCoverage = stmtsMissing === 0 && branchMissing === 0;
     if (xmlSkipCovered && isFullCoverage) {
         return null;
     }
-    const cover = isFullCoverage
-        ? '100%'
-        : `${parseInt(String(parseFloat(lineRate) * 100))}%`;
+    const coverPercent = computeCoverPercent(stmtsTotal - stmtsMissing, stmtsTotal, branchTotal - branchMissing, branchTotal);
+    const cover = isFullCoverage ? '100%' : `${parseInt(String(coverPercent))}%`;
     const result = { name, stmts, miss, cover, missing };
     if (branchTotal > 0) {
         result.branch = branchTotal.toString();

--- a/src/parseXml.ts
+++ b/src/parseXml.ts
@@ -22,17 +22,44 @@ const getParsedXml = (options: Options): ParsedXml => {
   return null;
 };
 
+// Combine statement and branch coverage into a single percentage, the same
+// way coverage.py's own `coverage report` does:
+// (executed statements + executed branches) / (total statements + total branches).
+// Cobertura tracks `line-rate` and `branch-rate` independently, so a file
+// with every statement executed but a partially-covered branch reports
+// line-rate="1" even though `coverage report` shows less than 100%.
+const computeCoverPercent = (
+  coveredStmts: number,
+  totalStmts: number,
+  coveredBranches: number,
+  totalBranches: number,
+): number => {
+  const numerator = coveredStmts + coveredBranches;
+  const denominator = totalStmts + totalBranches;
+
+  return denominator > 0 ? (numerator / denominator) * 100 : 100;
+};
+
 const getTotalCoverage = (parsedXml: ParsedXml): TotalLine | null => {
   if (!parsedXml) {
     return null;
   }
 
   const coverage = parsedXml['$'];
-  const cover = parseInt(String(parseFloat(coverage['line-rate']) * 100));
   const linesValid = parseInt(coverage['lines-valid']);
   const linesCovered = parseInt(coverage['lines-covered']);
   const branchesValid = parseInt(coverage['branches-valid']) || 0;
   const branchesCovered = parseInt(coverage['branches-covered']) || 0;
+  const cover = parseInt(
+    String(
+      computeCoverPercent(
+        linesCovered,
+        linesValid,
+        branchesCovered,
+        branchesValid,
+      ),
+    ),
+  );
 
   const result: TotalLine = {
     name: 'TOTAL',
@@ -169,16 +196,23 @@ const parseClass = (
     branchTotal,
     branchMissing,
   } = parseLines(classObj.lines);
-  const { filename: name, 'line-rate': lineRate } = classObj['$'];
-  const isFullCoverage = lineRate === '1';
+  const { filename: name } = classObj['$'];
+
+  const stmtsTotal = parseInt(stmts, 10);
+  const stmtsMissing = parseInt(miss, 10);
+  const isFullCoverage = stmtsMissing === 0 && branchMissing === 0;
 
   if (xmlSkipCovered && isFullCoverage) {
     return null;
   }
 
-  const cover = isFullCoverage
-    ? '100%'
-    : `${parseInt(String(parseFloat(lineRate) * 100))}%`;
+  const coverPercent = computeCoverPercent(
+    stmtsTotal - stmtsMissing,
+    stmtsTotal,
+    branchTotal - branchMissing,
+    branchTotal,
+  );
+  const cover = isFullCoverage ? '100%' : `${parseInt(String(coverPercent))}%`;
 
   const result: CoverageLine = { name, stmts, miss, cover, missing };
 


### PR DESCRIPTION
## **User description**
## What does this PR do?

When branch coverage is reported, the calculation of "covered" is incorrect. I.e., it can incorrectly show 100% even when there are partially covered branches.

Ideally, we would rely on `coverage.py` to calculate this, see #283 how this could be accomplished.

## Related Issue

Closes #283 

## Checklist

- [x] Tested locally
- [x] Ran `npm run all`
- [ ] Updated docs (if needed)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix coverage percentage when branch coverage is enabled by including covered branches in the calculation. Total and per-file coverage now match `coverage.py`’s report and no longer show 100% with partially covered branches.

- **Bug Fixes**
  - Compute cover as (covered statements + covered branches) / (total statements + total branches).
  - Mark files as fully covered only when both statements and branches have no misses; still respect xmlSkipCovered.
  - Update TOTAL and file rows to use the combined metric; add tests and changelog entry.

<sup>Written for commit 7f3a5d7d2b6906dbd71992d48bcbc45e2e5143bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MishaKav/pytest-coverage-comment/pull/284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Show correct coverage when branches are only partly covered**

### What Changed
- Coverage percentages now include both statement coverage and branch coverage, so files and totals no longer show 100% when some branches are still missed.
- Fully covered files are only hidden when both statements and branches are complete.
- Added a test that checks a file with uncovered branches reports 83% instead of 100%.

### Impact
`✅ Correct coverage totals with branch coverage`
`✅ Fewer false 100% coverage reports`
`✅ Clearer file-level coverage results`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
