### PR TITLE
fix: correct coverage percentage when branch coverage is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog of the Pytest Coverage Comment
 
-## Unreleased
+## [Pytest Coverage Comment 1.9.0](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.9.0)
 
-### Fixes
+**Release Date:** 2026-07-04
 
-- Show the correct Coverage percentage when using branch coverage to match what `coverage report` shows
+#### Changes
+
+- fix the Coverage percentage when branch coverage is enabled — it now combines statement and branch coverage and rounds the same way `coverage report` does, instead of showing `100%` when branches are only partially covered (#284), thanks to [@mschoettle](https://github.com/mschoettle) for contribution
 
 ## [Pytest Coverage Comment 1.8.0](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.8.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog of the Pytest Coverage Comment
 
+## Unreleased
+
+### Fixes
+
+- Show the correct Coverage percentage when using branch coverage to match what `coverage report` shows
+
 ## [Pytest Coverage Comment 1.8.0](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.8.0)
 
 **Release Date:** 2026-06-27

--- a/__tests__/parse.test.ts
+++ b/__tests__/parse.test.ts
@@ -260,6 +260,17 @@ describe('toHtml', () => {
     expect(html).toContain('(');
   });
 
+  test('text badge fraction stays statement-only for text reports with branches', () => {
+    // In coverage.py text reports BrPart is partial branches, not missing
+    // arcs, so the fraction must not use branch counts (TOTAL: 1345 1002 386 1 22%).
+    const content = getContentFile(
+      path.join(dataPath, 'pytest-coverage_6.txt'),
+    );
+    const options = { ...baseOptions, textInsteadBadge: true };
+    const html = toHtml(content, options);
+    expect(html).toContain('22% (343/1345)');
+  });
+
   test('should remove link from badge when removeLinkFromBadge is true', () => {
     const content = getContentFile(
       path.join(dataPath, 'pytest-coverage_4.txt'),

--- a/__tests__/parseXml.test.ts
+++ b/__tests__/parseXml.test.ts
@@ -84,6 +84,20 @@ describe('getCoverageXmlReport', () => {
     expect(result!.html).toContain('>63->66</a>');
   });
 
+  test('should include partial branches in the cover percentage, not just statement coverage', () => {
+    const covXmlFile = path.join(dataPath, 'coverage_3.xml');
+    const options = { ...baseOptions, covXmlFile };
+    const result = getCoverageXmlReport(options);
+
+    expect(result).not.toBeNull();
+    // foo.py has 0 missing statements (line-rate="1") but 2 of its 4 branches
+    // are uncovered, so `coverage report` shows 83%, not 100%. The file row
+    // and the TOTAL row should match that, the same as `coverage report`.
+    expect(result!.coverage!.cover).toBe('83%');
+    expect(result!.html).not.toContain('100%');
+    expect(result!.html).toContain('<td>83%</td>');
+  });
+
   test('should combine partial branches and show exit in arrows', () => {
     const covXmlFile = path.join(dataPath, 'coverage_3.xml');
     const options = { ...baseOptions, covXmlFile };

--- a/__tests__/parseXml.test.ts
+++ b/__tests__/parseXml.test.ts
@@ -94,8 +94,17 @@ describe('getCoverageXmlReport', () => {
     // are uncovered, so `coverage report` shows 83%, not 100%. The file row
     // and the TOTAL row should match that, the same as `coverage report`.
     expect(result!.coverage!.cover).toBe('83%');
-    expect(result!.html).not.toContain('100%');
     expect(result!.html).toContain('<td>83%</td>');
+  });
+
+  test('text badge fraction includes branches, matching the branch-aware percentage', () => {
+    const covXmlFile = path.join(dataPath, 'coverage_3.xml');
+    const options = { ...baseOptions, covXmlFile, textInsteadBadge: true };
+    const result = getCoverageXmlReport(options);
+
+    expect(result).not.toBeNull();
+    // 8/8 statements + 2/4 branches covered => 10/12, not the statement-only 8/8.
+    expect(result!.html).toContain('83% (10/12)');
   });
 
   test('should combine partial branches and show exit in arrows', () => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -39918,16 +39918,27 @@ const getParsedXml = (options) => {
     }
     return null;
 };
+// Combine statement and branch coverage into a single percentage, the same
+// way coverage.py's own `coverage report` does:
+// (executed statements + executed branches) / (total statements + total branches).
+// Cobertura tracks `line-rate` and `branch-rate` independently, so a file
+// with every statement executed but a partially-covered branch reports
+// line-rate="1" even though `coverage report` shows less than 100%.
+const computeCoverPercent = (coveredStmts, totalStmts, coveredBranches, totalBranches) => {
+    const numerator = coveredStmts + coveredBranches;
+    const denominator = totalStmts + totalBranches;
+    return denominator > 0 ? (numerator / denominator) * 100 : 100;
+};
 const getTotalCoverage = (parsedXml) => {
     if (!parsedXml) {
         return null;
     }
     const coverage = parsedXml['$'];
-    const cover = parseInt(String(parseFloat(coverage['line-rate']) * 100));
     const linesValid = parseInt(coverage['lines-valid']);
     const linesCovered = parseInt(coverage['lines-covered']);
     const branchesValid = parseInt(coverage['branches-valid']) || 0;
     const branchesCovered = parseInt(coverage['branches-covered']) || 0;
+    const cover = parseInt(String(computeCoverPercent(linesCovered, linesValid, branchesCovered, branchesValid)));
     const result = {
         name: 'TOTAL',
         stmts: linesValid,
@@ -40029,14 +40040,15 @@ const parseClass = (classObj, xmlSkipCovered) => {
         return null;
     }
     const { stmts, missing, totalMissing: miss, branchTotal, branchMissing, } = parseLines(classObj.lines);
-    const { filename: name, 'line-rate': lineRate } = classObj['$'];
-    const isFullCoverage = lineRate === '1';
+    const { filename: name } = classObj['$'];
+    const stmtsTotal = parseInt(stmts, 10);
+    const stmtsMissing = parseInt(miss, 10);
+    const isFullCoverage = stmtsMissing === 0 && branchMissing === 0;
     if (xmlSkipCovered && isFullCoverage) {
         return null;
     }
-    const cover = isFullCoverage
-        ? '100%'
-        : `${parseInt(String(parseFloat(lineRate) * 100))}%`;
+    const coverPercent = computeCoverPercent(stmtsTotal - stmtsMissing, stmtsTotal, branchTotal - branchMissing, branchTotal);
+    const cover = isFullCoverage ? '100%' : `${parseInt(String(coverPercent))}%`;
     const result = { name, stmts, miss, cover, missing };
     if (branchTotal > 0) {
         result.branch = branchTotal.toString();

--- a/dist/index.js
+++ b/dist/index.js
@@ -39727,9 +39727,10 @@ const toHtml = (data, options, dataFromXml = null) => {
         : `<a href="${readmeHref}">${badge}</a>`;
     const stmts = typeof total.stmts === 'number' ? total.stmts : parseInt(total.stmts);
     const miss = typeof total.miss === 'number' ? total.miss : parseInt(total.miss);
-    // include branches so the fraction matches the branch-aware %
-    const branch = total.branch ? parseInt(total.branch) : 0;
-    const brpart = total.brpart ? parseInt(total.brpart) : 0;
+    // brpart only means "missing branches" for XML totals; text reports use
+    // BrPart (partial branches), so keep the statement-only fraction there
+    const branch = dataFromXml && total.branch ? parseInt(total.branch) : 0;
+    const brpart = dataFromXml && total.brpart ? parseInt(total.brpart) : 0;
     const covered = stmts - miss + (branch - brpart);
     const totalCount = stmts + branch;
     const textBadge = `${total.cover} (${covered}/${totalCount})`;

--- a/dist/index.js
+++ b/dist/index.js
@@ -39725,9 +39725,14 @@ const toHtml = (data, options, dataFromXml = null) => {
     const badgeWithLink = removeLinkFromBadge
         ? badge
         : `<a href="${readmeHref}">${badge}</a>`;
-    const covered = (typeof total.stmts === 'number' ? total.stmts : parseInt(total.stmts)) -
-        (typeof total.miss === 'number' ? total.miss : parseInt(total.miss));
-    const textBadge = `${total.cover} (${covered}/${total.stmts})`;
+    const stmts = typeof total.stmts === 'number' ? total.stmts : parseInt(total.stmts);
+    const miss = typeof total.miss === 'number' ? total.miss : parseInt(total.miss);
+    // include branches so the fraction matches the branch-aware %
+    const branch = total.branch ? parseInt(total.branch) : 0;
+    const brpart = total.brpart ? parseInt(total.brpart) : 0;
+    const covered = stmts - miss + (branch - brpart);
+    const totalCount = stmts + branch;
+    const textBadge = `${total.cover} (${covered}/${totalCount})`;
     const badgeContent = textInsteadBadge ? textBadge : badgeWithLink;
     const badgeHtml = hideBadge ? '' : badgeContent;
     const reportHtml = hideReport
@@ -39927,7 +39932,25 @@ const getParsedXml = (options) => {
 const computeCoverPercent = (coveredStmts, totalStmts, coveredBranches, totalBranches) => {
     const numerator = coveredStmts + coveredBranches;
     const denominator = totalStmts + totalBranches;
+    // reject malformed (NaN) counts instead of reporting 100%
+    if (!Number.isFinite(numerator) || !Number.isFinite(denominator)) {
+        return NaN;
+    }
+    // empty file (no stmts/branches) counts as fully covered, like coverage.py
     return denominator > 0 ? (numerator / denominator) * 100 : 100;
+};
+// round like `coverage report`, but never round up to 100 or down to 0
+const formatCoverPercent = (percent) => {
+    if (!Number.isFinite(percent)) {
+        return NaN;
+    }
+    if (percent > 99 && percent < 100) {
+        return 99;
+    }
+    if (percent > 0 && percent < 1) {
+        return 1;
+    }
+    return Math.round(percent);
 };
 const getTotalCoverage = (parsedXml) => {
     if (!parsedXml) {
@@ -39938,7 +39961,12 @@ const getTotalCoverage = (parsedXml) => {
     const linesCovered = parseInt(coverage['lines-covered']);
     const branchesValid = parseInt(coverage['branches-valid']) || 0;
     const branchesCovered = parseInt(coverage['branches-covered']) || 0;
-    const cover = parseInt(String(computeCoverPercent(linesCovered, linesValid, branchesCovered, branchesValid)));
+    const cover = formatCoverPercent(computeCoverPercent(linesCovered, linesValid, branchesCovered, branchesValid));
+    if (!Number.isFinite(cover)) {
+        // prettier-ignore
+        core.warning(`Coverage xml file is missing valid total coverage attributes`);
+        return null;
+    }
     const result = {
         name: 'TOTAL',
         stmts: linesValid,
@@ -39972,7 +40000,7 @@ const getCoverageXmlReport = (options) => {
             // prettier-ignore
             core.error(`Error: coverage file "${options.covXmlFile}" has bad format or wrong data`);
         }
-        if (parsedXml && isValid) {
+        if (parsedXml && isValid && coverage) {
             const coverageObj = coverageXmlToFiles(parsedXml, options.xmlSkipCovered);
             const dataFromXml = {
                 coverage: coverageObj,
@@ -40048,7 +40076,9 @@ const parseClass = (classObj, xmlSkipCovered) => {
         return null;
     }
     const coverPercent = computeCoverPercent(stmtsTotal - stmtsMissing, stmtsTotal, branchTotal - branchMissing, branchTotal);
-    const cover = isFullCoverage ? '100%' : `${parseInt(String(coverPercent))}%`;
+    const cover = isFullCoverage
+        ? '100%'
+        : `${formatCoverPercent(coverPercent)}%`;
     const result = { name, stmts, miss, cover, missing };
     if (branchTotal > 0) {
         result.branch = branchTotal.toString();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pytest-coverage-comment",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pytest-coverage-comment",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pytest-coverage-comment",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Comments a pull request with the pytest code coverage badge, full report and tests summary",
   "author": "Misha Kav",
   "license": "MIT",

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -268,9 +268,10 @@ export const toHtml = (
     typeof total.stmts === 'number' ? total.stmts : parseInt(total.stmts);
   const miss =
     typeof total.miss === 'number' ? total.miss : parseInt(total.miss);
-  // include branches so the fraction matches the branch-aware %
-  const branch = total.branch ? parseInt(total.branch) : 0;
-  const brpart = total.brpart ? parseInt(total.brpart) : 0;
+  // brpart only means "missing branches" for XML totals; text reports use
+  // BrPart (partial branches), so keep the statement-only fraction there
+  const branch = dataFromXml && total.branch ? parseInt(total.branch) : 0;
+  const brpart = dataFromXml && total.brpart ? parseInt(total.brpart) : 0;
   const covered = stmts - miss + (branch - brpart);
   const totalCount = stmts + branch;
   const textBadge = `${total.cover} (${covered}/${totalCount})`;

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -264,10 +264,16 @@ export const toHtml = (
   const badgeWithLink = removeLinkFromBadge
     ? badge
     : `<a href="${readmeHref}">${badge}</a>`;
-  const covered =
-    (typeof total.stmts === 'number' ? total.stmts : parseInt(total.stmts)) -
-    (typeof total.miss === 'number' ? total.miss : parseInt(total.miss));
-  const textBadge = `${total.cover} (${covered}/${total.stmts})`;
+  const stmts =
+    typeof total.stmts === 'number' ? total.stmts : parseInt(total.stmts);
+  const miss =
+    typeof total.miss === 'number' ? total.miss : parseInt(total.miss);
+  // include branches so the fraction matches the branch-aware %
+  const branch = total.branch ? parseInt(total.branch) : 0;
+  const brpart = total.brpart ? parseInt(total.brpart) : 0;
+  const covered = stmts - miss + (branch - brpart);
+  const totalCount = stmts + branch;
+  const textBadge = `${total.cover} (${covered}/${totalCount})`;
   const badgeContent = textInsteadBadge ? textBadge : badgeWithLink;
   const badgeHtml = hideBadge ? '' : badgeContent;
   const reportHtml = hideReport

--- a/src/parseXml.ts
+++ b/src/parseXml.ts
@@ -37,7 +37,30 @@ const computeCoverPercent = (
   const numerator = coveredStmts + coveredBranches;
   const denominator = totalStmts + totalBranches;
 
+  // reject malformed (NaN) counts instead of reporting 100%
+  if (!Number.isFinite(numerator) || !Number.isFinite(denominator)) {
+    return NaN;
+  }
+
+  // empty file (no stmts/branches) counts as fully covered, like coverage.py
   return denominator > 0 ? (numerator / denominator) * 100 : 100;
+};
+
+// round like `coverage report`, but never round up to 100 or down to 0
+const formatCoverPercent = (percent: number): number => {
+  if (!Number.isFinite(percent)) {
+    return NaN;
+  }
+
+  if (percent > 99 && percent < 100) {
+    return 99;
+  }
+
+  if (percent > 0 && percent < 1) {
+    return 1;
+  }
+
+  return Math.round(percent);
 };
 
 const getTotalCoverage = (parsedXml: ParsedXml): TotalLine | null => {
@@ -50,16 +73,20 @@ const getTotalCoverage = (parsedXml: ParsedXml): TotalLine | null => {
   const linesCovered = parseInt(coverage['lines-covered']);
   const branchesValid = parseInt(coverage['branches-valid']) || 0;
   const branchesCovered = parseInt(coverage['branches-covered']) || 0;
-  const cover = parseInt(
-    String(
-      computeCoverPercent(
-        linesCovered,
-        linesValid,
-        branchesCovered,
-        branchesValid,
-      ),
+  const cover = formatCoverPercent(
+    computeCoverPercent(
+      linesCovered,
+      linesValid,
+      branchesCovered,
+      branchesValid,
     ),
   );
+
+  if (!Number.isFinite(cover)) {
+    // prettier-ignore
+    core.warning(`Coverage xml file is missing valid total coverage attributes`);
+    return null;
+  }
 
   const result: TotalLine = {
     name: 'TOTAL',
@@ -105,7 +132,7 @@ export const getCoverageXmlReport = (
       core.error(`Error: coverage file "${options.covXmlFile}" has bad format or wrong data`);
     }
 
-    if (parsedXml && isValid) {
+    if (parsedXml && isValid && coverage) {
       const coverageObj = coverageXmlToFiles(parsedXml, options.xmlSkipCovered);
       const dataFromXml: DataFromXml = {
         coverage: coverageObj,
@@ -212,7 +239,9 @@ const parseClass = (
     branchTotal - branchMissing,
     branchTotal,
   );
-  const cover = isFullCoverage ? '100%' : `${parseInt(String(coverPercent))}%`;
+  const cover = isFullCoverage
+    ? '100%'
+    : `${formatCoverPercent(coverPercent)}%`;
 
   const result: CoverageLine = { name, stmts, miss, cover, missing };
 

--- a/src/parseXml.ts
+++ b/src/parseXml.ts
@@ -22,17 +22,44 @@ const getParsedXml = (options: Options): ParsedXml => {
   return null;
 };
 
+// Combine statement and branch coverage into a single percentage, the same
+// way coverage.py's own `coverage report` does:
+// (executed statements + executed branches) / (total statements + total branches).
+// Cobertura tracks `line-rate` and `branch-rate` independently, so a file
+// with every statement executed but a partially-covered branch reports
+// line-rate="1" even though `coverage report` shows less than 100%.
+const computeCoverPercent = (
+  coveredStmts: number,
+  totalStmts: number,
+  coveredBranches: number,
+  totalBranches: number,
+): number => {
+  const numerator = coveredStmts + coveredBranches;
+  const denominator = totalStmts + totalBranches;
+
+  return denominator > 0 ? (numerator / denominator) * 100 : 100;
+};
+
 const getTotalCoverage = (parsedXml: ParsedXml): TotalLine | null => {
   if (!parsedXml) {
     return null;
   }
 
   const coverage = parsedXml['$'];
-  const cover = parseInt(String(parseFloat(coverage['line-rate']) * 100));
   const linesValid = parseInt(coverage['lines-valid']);
   const linesCovered = parseInt(coverage['lines-covered']);
   const branchesValid = parseInt(coverage['branches-valid']) || 0;
   const branchesCovered = parseInt(coverage['branches-covered']) || 0;
+  const cover = parseInt(
+    String(
+      computeCoverPercent(
+        linesCovered,
+        linesValid,
+        branchesCovered,
+        branchesValid,
+      ),
+    ),
+  );
 
   const result: TotalLine = {
     name: 'TOTAL',
@@ -169,16 +196,23 @@ const parseClass = (
     branchTotal,
     branchMissing,
   } = parseLines(classObj.lines);
-  const { filename: name, 'line-rate': lineRate } = classObj['$'];
-  const isFullCoverage = lineRate === '1';
+  const { filename: name } = classObj['$'];
+
+  const stmtsTotal = parseInt(stmts, 10);
+  const stmtsMissing = parseInt(miss, 10);
+  const isFullCoverage = stmtsMissing === 0 && branchMissing === 0;
 
   if (xmlSkipCovered && isFullCoverage) {
     return null;
   }
 
-  const cover = isFullCoverage
-    ? '100%'
-    : `${parseInt(String(parseFloat(lineRate) * 100))}%`;
+  const coverPercent = computeCoverPercent(
+    stmtsTotal - stmtsMissing,
+    stmtsTotal,
+    branchTotal - branchMissing,
+    branchTotal,
+  );
+  const cover = isFullCoverage ? '100%' : `${parseInt(String(coverPercent))}%`;
 
   const result: CoverageLine = { name, stmts, miss, cover, missing };
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -42,11 +42,7 @@ export interface ChangedFiles {
 }
 
 export type CoverageColor =
-  | 'red'
-  | 'orange'
-  | 'yellow'
-  | 'green'
-  | 'brightgreen';
+  'red' | 'orange' | 'yellow' | 'green' | 'brightgreen';
 
 export interface CoverageLine {
   name: string;


### PR DESCRIPTION
Continues #284 by @mschoettle (which landed on `fix-branch-coverage-percentage`), with hardening added on top.

## What
- combine statement + branch coverage and round the same way `coverage report` does (never rounding up to `100%` or down to `0%`)
- reject malformed coverage XML instead of falling back to `100%`
- make the text-badge fraction branch-aware (e.g. `10/12`, not `8/8`)
- bump to `1.9.0` + changelog entry

## Credit
Original branch-coverage fix by @mschoettle in #284. This PR carries that work plus the follow-up hardening to `main`.

## Test
`npm run all` green (95 tests). Added coverage for the partial-branch `83%` case and the branch-aware text badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)