### PR TITLE
feat: add coverage.py JSON report support (pytest-json-coverage-path)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog of the Pytest Coverage Comment
 
+## [Pytest Coverage Comment 1.10.0](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.10.0)
+
+**Release Date:** 2026-07-05
+
+#### Changes
+
+- add support for parsing the JSON coverage report from `coverage json` via the new `pytest-json-coverage-path` input, including branch coverage and partial-branch arrows (`line->target`, `line->exit`) that match `coverage report -m` (#286)
+
 ## [Pytest Coverage Comment 1.9.0](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.9.0)
 
 **Release Date:** 2026-07-04

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ The codebase is a TypeScript GitHub Action with the following key components:
 
 - **src/parse.ts**: Parses pytest text coverage output (e.g., from `pytest --cov`)
 - **src/parseXml.ts**: Parses XML coverage reports (e.g., from `pytest --cov-report=xml`)
+- **src/parseJson.ts**: Parses `coverage json` reports; returns the same `XmlCoverageReport` shape as parseXml and reuses `toHtml` + `DataFromXml`
 - **src/junitXml.ts**: Parses JUnit XML test results for test statistics
 
 ### Supporting Modules
@@ -99,6 +100,10 @@ The codebase is a TypeScript GitHub Action with the following key components:
 - Supports filtering to show only changed files in the current commit
 - Can skip files with 100% coverage from XML reports
 - Handles both absolute and relative file paths for coverage inputs
+- Coverage parser precedence (index.ts, cli.ts, multiFiles.ts): JSON > XML > TXT. multiFiles picks the parser by file extension (`.json`/`.xml`, else txt). JSON and XML expose `coverage` as a `TotalLine` object; TXT exposes it as a string
+- coverage.py JSON schema (from `coverage json`): top-level key is `totals` (not `summary`); per-file `summary.missing_lines` is a **count** while `file.missing_lines` is an **array**; `missing_branches` arcs are `[from, to]` pairs where a negative `to` means an exit arc (`from->exit`)
+- The JSON "Missing" column matches `coverage report -m`: a branch arc whose destination is an already-missing line is omitted (the line shows on its own). The XML parser predates this and shows a redundant `from->dest` arrow in that case — a known minor divergence, not fixed to keep the diff minimal
+- `formatCoverPercent` (exported from parseXml.ts) is the shared rounding helper (caps 99.x→99, floors 0.x→1); JSON uses coverage.py's precomputed `percent_covered` so it never needs `computeCoverPercent`
 - xml2js `parseString` is used synchronously via callback pattern (not async)
 - `@actions/github` has ESM/CJS compatibility issues in test context — mock it with `vi.mock()` in tests
 - `@actions/core` v3+ and `@actions/github` v9+ are pure ESM — incompatible with ncc's webpack CJS bundling. Must stay on `@actions/core` v2.x and `@actions/github` v8.x until ncc supports ESM or the project switches bundlers

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ jobs:
 | `github-token`             | ✓        | `${{github.token}}`     | GitHub token for API access to create/update comments                                  |
 | `pytest-coverage-path`     |          | `./pytest-coverage.txt` | Path to pytest text coverage output (from `--cov-report=term-missing`)                 |
 | `pytest-xml-coverage-path` |          |                         | Path to XML coverage report (from `--cov-report=xml:coverage.xml`)                     |
+| `pytest-json-coverage-path`|          |                         | Path to JSON coverage report (from `coverage json`)                                    |
 | `junitxml-path`            |          |                         | Path to JUnit XML file for test statistics (passed/failed/skipped)                     |
 | `issue-number`             |          |                         | Pull request number to comment on (required for workflow_dispatch/workflow_run events) |
 
@@ -246,6 +247,28 @@ jobs:
   uses: MishaKav/pytest-coverage-comment@v1
   with:
     pytest-xml-coverage-path: ./coverage.xml
+    junitxml-path: ./pytest.xml
+```
+
+</details>
+
+### Coverage from JSON
+
+<details>
+<summary>Using coverage.json instead of text output</summary>
+
+The JSON report's coverage percentages match `coverage report` exactly (statements and branches combined), and it is the most robust format to parse.
+
+```yaml
+- name: Generate JSON coverage
+  run: |
+    pytest --cov=src tests/
+    coverage json -o coverage.json
+
+- name: Coverage comment
+  uses: MishaKav/pytest-coverage-comment@v1
+  with:
+    pytest-json-coverage-path: ./coverage.json
     junitxml-path: ./pytest.xml
 ```
 

--- a/__tests__/junitXml.test.ts
+++ b/__tests__/junitXml.test.ts
@@ -21,6 +21,7 @@ const baseOptions: Options = {
   pathPrefix: '',
   covFile: '',
   covXmlFile: '',
+  covJsonFile: '',
   xmlFile: '',
   title: 'Coverage Report',
   badgeTitle: 'Coverage',

--- a/__tests__/multiFiles.test.ts
+++ b/__tests__/multiFiles.test.ts
@@ -17,6 +17,7 @@ const baseOptions: Options = {
   pathPrefix: '',
   covFile: '',
   covXmlFile: '',
+  covJsonFile: '',
   xmlFile: '',
   title: 'Coverage Report',
   badgeTitle: 'Coverage',

--- a/__tests__/parse.test.ts
+++ b/__tests__/parse.test.ts
@@ -27,6 +27,7 @@ const baseOptions: Options = {
   pathPrefix: '',
   covFile: '',
   covXmlFile: '',
+  covJsonFile: '',
   xmlFile: '',
   title: 'Coverage Report',
   badgeTitle: 'Coverage',

--- a/__tests__/parseJson.test.ts
+++ b/__tests__/parseJson.test.ts
@@ -1,0 +1,190 @@
+import { expect, test, describe, beforeEach } from 'vitest';
+import * as path from 'path';
+import { getCoverageJsonReport, exportedForTesting } from '../src/parseJson';
+import { spyCore } from './setup';
+import type { Options } from '../src/types';
+
+const { isValidCoverageContent, collapseRanges, getMissing, getTotalCoverage } =
+  exportedForTesting;
+
+type MissingArg = Parameters<typeof getMissing>[0];
+type TotalsArg = Parameters<typeof getTotalCoverage>[0];
+
+const dataPath = path.resolve(__dirname, '..', 'data');
+
+const baseOptions: Options = {
+  token: 'token_123',
+  repository: 'MishaKav/pytest-coverage-comment',
+  commit: 'abc123',
+  prefix: '',
+  pathPrefix: '',
+  covFile: '',
+  covXmlFile: '',
+  covJsonFile: '',
+  xmlFile: '',
+  title: 'Coverage Report',
+  badgeTitle: 'Coverage',
+  hideBadge: false,
+  hideReport: false,
+  createNewComment: false,
+  hideComment: false,
+  hideEmoji: false,
+  xmlSkipCovered: false,
+  reportOnlyChangedFiles: false,
+  removeLinkFromBadge: false,
+  removeLinksToFiles: false,
+  removeLinksToLines: false,
+  textInsteadBadge: false,
+  defaultBranch: 'main',
+  xmlTitle: '',
+  multipleFiles: [],
+  repoUrl: 'https://github.com/MishaKav/pytest-coverage-comment',
+};
+
+describe('getCoverageJsonReport', () => {
+  beforeEach(() => {
+    spyCore.error.mockClear();
+    spyCore.warning.mockClear();
+    spyCore.info.mockClear();
+  });
+
+  test('should return null for empty covJsonFile', () => {
+    const result = getCoverageJsonReport(baseOptions);
+    expect(result).toBeNull();
+  });
+
+  test('should return null for non-existent file', () => {
+    const options = { ...baseOptions, covJsonFile: '/nonexistent/coverage.json' };
+    const result = getCoverageJsonReport(options);
+    expect(result).toBeNull();
+  });
+
+  test('should warn and return null for malformed json', () => {
+    const covJsonFile = path.join(dataPath, 'coverage_1.xml'); // not json
+    const options = { ...baseOptions, covJsonFile };
+    const result = getCoverageJsonReport(options);
+
+    expect(result).toBeNull();
+    expect(spyCore.warning).toHaveBeenCalled();
+  });
+
+  test('should parse coverage_1.json (no branches) successfully', () => {
+    const covJsonFile = path.join(dataPath, 'coverage_1.json');
+    const options = { ...baseOptions, covJsonFile };
+    const result = getCoverageJsonReport(options);
+
+    expect(result).not.toBeNull();
+    expect(result!.html).toContain('img.shields.io/badge');
+    expect(result!.coverage).not.toBeNull();
+    expect(result!.coverage!.name).toBe('TOTAL');
+    expect(result!.coverage!.cover).toBe('88%');
+    // foo.py is 80% with missing lines 5 and 12
+    expect(result!.html).toContain('<td>80%</td>');
+    expect(result!.html).toContain('>5</a>');
+    expect(result!.html).toContain('>12</a>');
+    // no branch columns for a statement-only report
+    expect(result!.html).not.toContain('<th>Branch</th>');
+  });
+
+  test('should parse coverage_2.json with branch coverage', () => {
+    const covJsonFile = path.join(dataPath, 'coverage_2.json');
+    const options = { ...baseOptions, covJsonFile };
+    const result = getCoverageJsonReport(options);
+
+    expect(result).not.toBeNull();
+    expect(result!.coverage!.cover).toBe('82%');
+    expect(result!.coverage!.branch).toBe('10');
+    expect(result!.coverage!.brpart).toBe('3');
+    expect(result!.html).toContain('<th>Branch</th><th>BrPart</th>');
+    // branch arcs from getMissing are wired into the missing column
+    expect(result!.html).toContain('>2->exit</a>');
+  });
+
+  test('should skip covered files when xmlSkipCovered is true', () => {
+    const covJsonFile = path.join(dataPath, 'coverage_1.json');
+    const options = { ...baseOptions, covJsonFile, xmlSkipCovered: true };
+    const result = getCoverageJsonReport(options);
+
+    expect(result).not.toBeNull();
+    // bar.py is 100% covered and should be excluded from the table
+    expect(result!.html).not.toContain('bar.py');
+    expect(result!.html).toContain('foo.py');
+  });
+});
+
+describe('parseJson internals', () => {
+  test('isValidCoverageContent', () => {
+    expect(isValidCoverageContent(null)).toBe(false);
+    expect(isValidCoverageContent({ files: {} } as never)).toBe(false);
+    expect(isValidCoverageContent({ files: {}, totals: {} } as never)).toBe(
+      true,
+    );
+  });
+
+  test('collapseRanges groups consecutive lines', () => {
+    expect(collapseRanges([4, 10, 11, 12])).toEqual([
+      { sort: 4, text: '4' },
+      { sort: 10, text: '10-12' },
+    ]);
+    expect(collapseRanges([])).toEqual([]);
+  });
+
+  test('getMissing renders lines, exit arcs, and normal arcs sorted by line', () => {
+    const asArg = (file: {
+      missing_lines: number[];
+      missing_branches: number[][];
+    }): MissingArg => file as unknown as MissingArg;
+
+    expect(
+      getMissing(asArg({ missing_lines: [5, 14], missing_branches: [[2, 5]] })),
+    ).toEqual(['5', '14']);
+    expect(
+      getMissing(asArg({ missing_lines: [], missing_branches: [[2, -1]] })),
+    ).toEqual(['2->exit']);
+    expect(
+      getMissing(asArg({ missing_lines: [], missing_branches: [[2, 4]] })),
+    ).toEqual(['2->4']);
+    expect(
+      getMissing(asArg({ missing_lines: [6], missing_branches: [[2, 4]] })),
+    ).toEqual(['2->4', '6']);
+  });
+
+  test('getTotalCoverage maps totals to a TotalLine', () => {
+    expect(
+      getTotalCoverage({
+        num_statements: 16,
+        missing_lines: 2,
+        percent_covered: 87.5,
+      } as TotalsArg),
+    ).toEqual({ name: 'TOTAL', stmts: 16, miss: 2, cover: '88%' });
+
+    expect(
+      getTotalCoverage({
+        num_statements: 18,
+        missing_lines: 2,
+        percent_covered: 82.14,
+        num_branches: 10,
+        missing_branches: 3,
+      } as TotalsArg),
+    ).toEqual({
+      name: 'TOTAL',
+      stmts: 18,
+      miss: 2,
+      cover: '82%',
+      branch: '10',
+      brpart: '3',
+    });
+  });
+
+  test('getTotalCoverage returns null for a non-finite percentage', () => {
+    spyCore.warning.mockClear();
+    expect(
+      getTotalCoverage({
+        num_statements: 0,
+        missing_lines: 0,
+        percent_covered: NaN,
+      } as TotalsArg),
+    ).toBeNull();
+    expect(spyCore.warning).toHaveBeenCalled();
+  });
+});

--- a/__tests__/parseXml.test.ts
+++ b/__tests__/parseXml.test.ts
@@ -14,6 +14,7 @@ const baseOptions: Options = {
   pathPrefix: '',
   covFile: '',
   covXmlFile: '',
+  covJsonFile: '',
   xmlFile: '',
   title: 'Coverage Report',
   badgeTitle: 'Coverage',

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,11 @@ inputs:
     default: ''
     required: false
 
+  pytest-json-coverage-path:
+    description: 'Path to JSON coverage report (from coverage json)'
+    default: ''
+    required: false
+
   coverage-path-prefix:
     description: 'Prefix to add to file paths in coverage report links'
     default: ''
@@ -95,7 +100,7 @@ inputs:
     description: >
       Generate single comment with multiple coverage reports (useful for monorepos).
       Format: One report per line as "Title, coverage-path, junit-path".
-      Coverage path can be TXT (from --cov-report=term-missing) or XML (from --cov-report=xml).
+      Coverage path can be TXT (from --cov-report=term-missing), XML (from --cov-report=xml), or JSON (from coverage json).
       Examples: "Backend API, ./backend/coverage.txt, ./backend/junit.xml"
       "Frontend Tests, ./frontend/coverage.xml, ./frontend/junit.xml"
     default: ''

--- a/data/coverage_1.json
+++ b/data/coverage_1.json
@@ -1,0 +1,44 @@
+{
+  "meta": {
+    "format": 3,
+    "version": "7.15.0",
+    "branch_coverage": false,
+    "show_contexts": false
+  },
+  "files": {
+    "src/foo.py": {
+      "executed_lines": [1, 2, 3, 4, 6, 7, 8, 9],
+      "summary": {
+        "covered_lines": 8,
+        "num_statements": 10,
+        "percent_covered": 80.0,
+        "percent_covered_display": "80",
+        "missing_lines": 2,
+        "excluded_lines": 0
+      },
+      "missing_lines": [5, 12],
+      "excluded_lines": []
+    },
+    "src/bar.py": {
+      "executed_lines": [1, 2, 3, 4, 5, 6],
+      "summary": {
+        "covered_lines": 6,
+        "num_statements": 6,
+        "percent_covered": 100.0,
+        "percent_covered_display": "100",
+        "missing_lines": 0,
+        "excluded_lines": 0
+      },
+      "missing_lines": [],
+      "excluded_lines": []
+    }
+  },
+  "totals": {
+    "covered_lines": 14,
+    "num_statements": 16,
+    "percent_covered": 87.5,
+    "percent_covered_display": "88",
+    "missing_lines": 2,
+    "excluded_lines": 0
+  }
+}

--- a/data/coverage_2.json
+++ b/data/coverage_2.json
@@ -1,0 +1,76 @@
+{
+  "meta": {
+    "format": 3,
+    "version": "7.15.0",
+    "branch_coverage": true,
+    "show_contexts": false
+  },
+  "files": {
+    "src/app.py": {
+      "executed_lines": [1, 2, 3, 7, 8, 9, 10, 11, 13],
+      "summary": {
+        "covered_lines": 9,
+        "num_statements": 11,
+        "percent_covered": 82.35294117647058,
+        "percent_covered_display": "82",
+        "missing_lines": 2,
+        "excluded_lines": 0,
+        "num_branches": 6,
+        "num_partial_branches": 1,
+        "covered_branches": 5,
+        "missing_branches": 1
+      },
+      "missing_lines": [5, 14],
+      "excluded_lines": [],
+      "missing_branches": [[2, 5]]
+    },
+    "src/utils.py": {
+      "executed_lines": [1, 2, 3],
+      "summary": {
+        "covered_lines": 3,
+        "num_statements": 3,
+        "percent_covered": 80.0,
+        "percent_covered_display": "80",
+        "missing_lines": 0,
+        "excluded_lines": 0,
+        "num_branches": 2,
+        "num_partial_branches": 1,
+        "covered_branches": 1,
+        "missing_branches": 1
+      },
+      "missing_lines": [],
+      "excluded_lines": [],
+      "missing_branches": [[2, -1]]
+    },
+    "src/normal.py": {
+      "executed_lines": [1, 2, 3, 4],
+      "summary": {
+        "covered_lines": 4,
+        "num_statements": 4,
+        "percent_covered": 83.33333333333333,
+        "percent_covered_display": "83",
+        "missing_lines": 0,
+        "excluded_lines": 0,
+        "num_branches": 2,
+        "num_partial_branches": 1,
+        "covered_branches": 1,
+        "missing_branches": 1
+      },
+      "missing_lines": [],
+      "excluded_lines": [],
+      "missing_branches": [[2, 4]]
+    }
+  },
+  "totals": {
+    "covered_lines": 16,
+    "num_statements": 18,
+    "percent_covered": 82.14285714285714,
+    "percent_covered_display": "82",
+    "missing_lines": 2,
+    "excluded_lines": 0,
+    "num_branches": 10,
+    "num_partial_branches": 3,
+    "covered_branches": 7,
+    "missing_branches": 3
+  }
+}

--- a/dist/index.js
+++ b/dist/index.js
@@ -38612,6 +38612,7 @@ const core = __importStar(__nccwpck_require__(7484));
 const github = __importStar(__nccwpck_require__(3228));
 const parse_1 = __nccwpck_require__(2828);
 const parseXml_1 = __nccwpck_require__(1775);
+const parseJson_1 = __nccwpck_require__(7258);
 const junitXml_1 = __nccwpck_require__(5394);
 const multiFiles_1 = __nccwpck_require__(6211);
 const MAX_COMMENT_LENGTH = 65536;
@@ -38766,6 +38767,9 @@ const main = async () => {
     const covXmlFile = core.getInput('pytest-xml-coverage-path', {
         required: false,
     });
+    const covJsonFile = core.getInput('pytest-json-coverage-path', {
+        required: false,
+    });
     const pathPrefix = core.getInput('coverage-path-prefix', { required: false });
     const xmlFile = core.getInput('junitxml-path', { required: false });
     const xmlTitle = core.getInput('junitxml-title', { required: false });
@@ -38789,6 +38793,7 @@ const main = async () => {
         pathPrefix,
         covFile,
         covXmlFile,
+        covJsonFile,
         xmlFile,
         title,
         badgeTitle,
@@ -38840,9 +38845,16 @@ const main = async () => {
             options.reportOnlyChangedFiles = false;
         }
     }
-    let report = options.covXmlFile
-        ? (0, parseXml_1.getCoverageXmlReport)(options)
-        : (0, parse_1.getCoverageReport)(options);
+    let report;
+    if (options.covJsonFile) {
+        report = (0, parseJson_1.getCoverageJsonReport)(options);
+    }
+    else if (options.covXmlFile) {
+        report = (0, parseXml_1.getCoverageXmlReport)(options);
+    }
+    else {
+        report = (0, parse_1.getCoverageReport)(options);
+    }
     if (!report) {
         report = { html: '', coverage: null, color: 'red' };
     }
@@ -38855,9 +38867,16 @@ const main = async () => {
     }
     if (html) {
         const newOptions = { ...options, commit: defaultBranch };
-        const output = newOptions.covXmlFile
-            ? (0, parseXml_1.getCoverageXmlReport)(newOptions)
-            : (0, parse_1.getCoverageReport)(newOptions);
+        let output;
+        if (newOptions.covJsonFile) {
+            output = (0, parseJson_1.getCoverageJsonReport)(newOptions);
+        }
+        else if (newOptions.covXmlFile) {
+            output = (0, parseXml_1.getCoverageXmlReport)(newOptions);
+        }
+        else {
+            output = (0, parse_1.getCoverageReport)(newOptions);
+        }
         if (output) {
             core.setOutput('coverageHtml', output.html);
         }
@@ -38904,9 +38923,15 @@ const main = async () => {
             warningsArr.push('- Add "remove-links-to-lines: true" to remove line number links');
         }
         core.warning(warningsArr.join('\n'));
-        report = options.covXmlFile
-            ? (0, parseXml_1.getCoverageXmlReport)({ ...options, hideReport: true })
-            : (0, parse_1.getCoverageReport)({ ...options, hideReport: true });
+        if (options.covJsonFile) {
+            report = (0, parseJson_1.getCoverageJsonReport)({ ...options, hideReport: true });
+        }
+        else if (options.covXmlFile) {
+            report = (0, parseXml_1.getCoverageXmlReport)({ ...options, hideReport: true });
+        }
+        else {
+            report = (0, parse_1.getCoverageReport)({ ...options, hideReport: true });
+        }
         if (!report) {
             report = { html: '', coverage: null, color: 'red' };
         }
@@ -39378,6 +39403,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.exportedForTesting = exports.getMultipleReport = void 0;
 const parse_1 = __nccwpck_require__(2828);
 const parseXml_1 = __nccwpck_require__(1775);
+const parseJson_1 = __nccwpck_require__(7258);
 const junitXml_1 = __nccwpck_require__(5394);
 const core = __importStar(__nccwpck_require__(7484));
 // parse oneline from multiple files to object
@@ -39393,14 +39419,16 @@ const parseLine = (line) => {
     };
 };
 // make internal options
-// covFile and covXmlFile are mutually exclusive — detected by .xml extension
+// covFile, covXmlFile and covJsonFile are mutually exclusive — detected by extension
 const getOptions = (options, line) => {
     const isXmlCoverage = line.covFile && line.covFile.toLowerCase().endsWith('.xml');
+    const isJsonCoverage = line.covFile && line.covFile.toLowerCase().endsWith('.json');
     return {
         ...options,
         title: line.title,
-        covFile: isXmlCoverage ? '' : line.covFile,
+        covFile: isXmlCoverage || isJsonCoverage ? '' : line.covFile,
         covXmlFile: isXmlCoverage ? line.covFile : '',
+        covJsonFile: isJsonCoverage ? line.covFile : '',
         hideReport: true,
         xmlFile: line.xmlFile,
         xmlTitle: '',
@@ -39423,32 +39451,48 @@ const getMultipleReport = (options) => {
         let table = hasXmlReports ? fullTable : miniTable;
         lineReports.forEach((l, i) => {
             const internalOptions = getOptions(options, l);
-            const report = internalOptions.covXmlFile
-                ? (0, parseXml_1.getCoverageXmlReport)(internalOptions)
-                : (0, parse_1.getCoverageReport)(internalOptions);
+            let report;
+            if (internalOptions.covJsonFile) {
+                report = (0, parseJson_1.getCoverageJsonReport)(internalOptions);
+            }
+            else if (internalOptions.covXmlFile) {
+                report = (0, parseXml_1.getCoverageXmlReport)(internalOptions);
+            }
+            else {
+                report = (0, parse_1.getCoverageReport)(internalOptions);
+            }
             const summary = (0, junitXml_1.getParsedXml)(internalOptions);
             if (report && report.html) {
                 table += `| ${l.title} | ${report.html}`;
                 if (i === 0) {
-                    core.startGroup(internalOptions.covXmlFile || internalOptions.covFile);
-                    const coverageValue = internalOptions.covXmlFile
+                    core.startGroup(internalOptions.covXmlFile ||
+                        internalOptions.covJsonFile ||
+                        internalOptions.covFile);
+                    const coverageValue = internalOptions.covXmlFile || internalOptions.covJsonFile
                         ? report.coverage?.cover || ''
                         : report.coverage;
                     core.info(`coverage: ${coverageValue}`);
                     core.info(`color: ${report.color}`);
-                    if (!internalOptions.covXmlFile) {
+                    if (!internalOptions.covXmlFile && !internalOptions.covJsonFile) {
                         core.info(`warnings: ${report.warnings}`);
                     }
                     core.endGroup();
                     core.setOutput('coverage', coverageValue);
                     core.setOutput('color', report.color);
-                    if (!internalOptions.covXmlFile) {
+                    if (!internalOptions.covXmlFile && !internalOptions.covJsonFile) {
                         core.setOutput('warnings', report.warnings);
                     }
                     const newOptions = { ...internalOptions, commit: defaultBranch };
-                    const output = newOptions.covXmlFile
-                        ? (0, parseXml_1.getCoverageXmlReport)(newOptions)
-                        : (0, parse_1.getCoverageReport)(newOptions);
+                    let output;
+                    if (newOptions.covJsonFile) {
+                        output = (0, parseJson_1.getCoverageJsonReport)(newOptions);
+                    }
+                    else if (newOptions.covXmlFile) {
+                        output = (0, parseXml_1.getCoverageXmlReport)(newOptions);
+                    }
+                    else {
+                        output = (0, parse_1.getCoverageReport)(newOptions);
+                    }
                     if (output) {
                         core.setOutput('coverageHtml', output.html);
                     }
@@ -39872,6 +39916,189 @@ exports.exportedForTesting = {
 
 /***/ }),
 
+/***/ 7258:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.exportedForTesting = exports.getCoverageJsonReport = void 0;
+const core = __importStar(__nccwpck_require__(7484));
+const utils_1 = __nccwpck_require__(1798);
+const parse_1 = __nccwpck_require__(2828);
+const parseXml_1 = __nccwpck_require__(1775);
+// read and parse the json coverage file
+const getParsedJson = (options) => {
+    const content = (0, utils_1.getContent)(options.covJsonFile);
+    if (!content || !content.length) {
+        return null;
+    }
+    try {
+        return JSON.parse(content);
+    }
+    catch (error) {
+        // prettier-ignore
+        core.warning(`Coverage json file is not valid JSON: ${error.message}`);
+        return null;
+    }
+};
+// return true if the parsed json includes the expected structure
+const isValidCoverageContent = (parsedJson) => !!parsedJson && !!parsedJson.files && !!parsedJson.totals;
+// collapse a sorted list of line numbers into range strings, e.g.
+// [4, 10, 11, 12] -> ["4", "10-12"]
+const collapseRanges = (lineNumbers) => lineNumbers
+    .slice()
+    .sort((a, b) => a - b)
+    .reduce((arr, val, i, a) => {
+    if (!i || val !== a[i - 1] + 1)
+        arr.push([]);
+    arr[arr.length - 1].push(val);
+    return arr;
+}, [])
+    .map((range) => ({
+    sort: range[0],
+    text: range.length === 1
+        ? `${range[0]}`
+        : `${range[0]}-${range[range.length - 1]}`,
+}));
+// build the "Missing" column entries the same way `coverage report -m` does:
+// missing statement lines as ranges, plus partial branch arcs as `from->to`
+// (or `from->exit`). An arc whose destination is itself a missing line is
+// omitted, since the line already appears as missing.
+const getMissing = (file) => {
+    const missingLines = file.missing_lines || [];
+    const missingLinesSet = new Set(missingLines);
+    const entries = collapseRanges(missingLines);
+    (file.missing_branches || []).forEach(([from, to]) => {
+        if (to < 0) {
+            entries.push({ sort: from, text: `${from}->exit` });
+        }
+        else if (!missingLinesSet.has(to)) {
+            entries.push({ sort: from, text: `${from}->${to}` });
+        }
+    });
+    return entries.sort((a, b) => a.sort - b.sort).map((e) => e.text);
+};
+// convert a single file entry to CoverageLine
+const parseFile = (name, file, xmlSkipCovered) => {
+    const { summary } = file;
+    const numBranches = summary.num_branches || 0;
+    const missingBranches = summary.missing_branches || 0;
+    const isFullCoverage = summary.missing_lines === 0 && missingBranches === 0;
+    if (xmlSkipCovered && isFullCoverage) {
+        return null;
+    }
+    const cover = isFullCoverage
+        ? '100%'
+        : `${(0, parseXml_1.formatCoverPercent)(summary.percent_covered)}%`;
+    const result = {
+        name,
+        stmts: summary.num_statements.toString(),
+        miss: summary.missing_lines.toString(),
+        cover,
+        missing: getMissing(file),
+    };
+    if (numBranches > 0) {
+        result.branch = numBranches.toString();
+        result.brpart = missingBranches.toString();
+    }
+    return result;
+};
+// convert the top-level totals to a TotalLine
+const getTotalCoverage = (totals) => {
+    const cover = (0, parseXml_1.formatCoverPercent)(totals.percent_covered);
+    const numBranches = totals.num_branches || 0;
+    if (!Number.isFinite(cover)) {
+        // prettier-ignore
+        core.warning(`Coverage json file is missing a valid total coverage percentage`);
+        return null;
+    }
+    const result = {
+        name: 'TOTAL',
+        stmts: totals.num_statements,
+        miss: totals.missing_lines,
+        cover: cover !== 0 ? `${cover}%` : '0',
+    };
+    if (numBranches > 0) {
+        result.branch = numBranches.toString();
+        result.brpart = (totals.missing_branches || 0).toString();
+    }
+    return result;
+};
+// return summary report in markdown format
+const getCoverageJsonReport = (options) => {
+    try {
+        const parsedJson = getParsedJson(options);
+        if (parsedJson && !isValidCoverageContent(parsedJson)) {
+            // prettier-ignore
+            core.error(`Error: coverage file "${options.covJsonFile}" has bad format or wrong data`);
+            return null;
+        }
+        const coverage = parsedJson ? getTotalCoverage(parsedJson.totals) : null;
+        if (parsedJson && coverage) {
+            const coverageObj = Object.entries(parsedJson.files)
+                .map(([name, file]) => parseFile(name, file, options.xmlSkipCovered))
+                .filter((line) => line !== null);
+            const dataFromXml = {
+                coverage: coverageObj,
+                total: coverage,
+            };
+            const html = (0, parse_1.toHtml)(null, options, dataFromXml);
+            const color = (0, utils_1.getCoverageColor)(coverage.cover);
+            return { html, coverage, color };
+        }
+        return null;
+    }
+    catch (error) {
+        // prettier-ignore
+        core.error(`Error generating coverage report from "${options.covJsonFile}". ${error.message}`);
+    }
+    return null;
+};
+exports.getCoverageJsonReport = getCoverageJsonReport;
+exports.exportedForTesting = {
+    isValidCoverageContent,
+    collapseRanges,
+    getMissing,
+    getTotalCoverage,
+};
+
+
+/***/ }),
+
 /***/ 1775:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
@@ -39911,7 +40138,7 @@ var __importStar = (this && this.__importStar) || (function () {
     };
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getCoverageXmlReport = void 0;
+exports.getCoverageXmlReport = exports.formatCoverPercent = void 0;
 const xml2js = __importStar(__nccwpck_require__(758));
 const core = __importStar(__nccwpck_require__(7484));
 const utils_1 = __nccwpck_require__(1798);
@@ -39953,6 +40180,7 @@ const formatCoverPercent = (percent) => {
     }
     return Math.round(percent);
 };
+exports.formatCoverPercent = formatCoverPercent;
 const getTotalCoverage = (parsedXml) => {
     if (!parsedXml) {
         return null;
@@ -39962,7 +40190,7 @@ const getTotalCoverage = (parsedXml) => {
     const linesCovered = parseInt(coverage['lines-covered']);
     const branchesValid = parseInt(coverage['branches-valid']) || 0;
     const branchesCovered = parseInt(coverage['branches-covered']) || 0;
-    const cover = formatCoverPercent(computeCoverPercent(linesCovered, linesValid, branchesCovered, branchesValid));
+    const cover = (0, exports.formatCoverPercent)(computeCoverPercent(linesCovered, linesValid, branchesCovered, branchesValid));
     if (!Number.isFinite(cover)) {
         // prettier-ignore
         core.warning(`Coverage xml file is missing valid total coverage attributes`);
@@ -40079,7 +40307,7 @@ const parseClass = (classObj, xmlSkipCovered) => {
     const coverPercent = computeCoverPercent(stmtsTotal - stmtsMissing, stmtsTotal, branchTotal - branchMissing, branchTotal);
     const cover = isFullCoverage
         ? '100%'
-        : `${formatCoverPercent(coverPercent)}%`;
+        : `${(0, exports.formatCoverPercent)(coverPercent)}%`;
     const result = { name, stmts, miss, cover, missing };
     if (branchTotal > 0) {
         result.branch = branchTotal.toString();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pytest-coverage-comment",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pytest-coverage-comment",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pytest-coverage-comment",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Comments a pull request with the pytest code coverage badge, full report and tests summary",
   "author": "Misha Kav",
   "license": "MIT",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import { getCoverageReport } from './parse';
 import { getSummaryReport, getParsedXml, getNotSuccessTest } from './junitXml';
 import { getMultipleReport } from './multiFiles';
 import { getCoverageXmlReport } from './parseXml';
+import { getCoverageJsonReport } from './parseJson';
 import type { Options } from './types';
 
 /*
@@ -34,6 +35,7 @@ const main = async (): Promise<void> => {
   const covFile = './../data/pytest-coverage_4.txt';
   const xmlFile = './../data/pytest_1.xml';
   const covXmlFile = './../data/coverage_1.xml'; // use coverage_2.xml for branch coverage
+  const covJsonFile = ''; // e.g. './../data/coverage_2.json' to test json parsing
   const prefix = path.dirname(path.dirname(path.resolve(covFile))) + '/';
   const multipleFiles = [
     `My Title 1, ${getPathToFile(covFile)}, ${getPathToFile(xmlFile)}`,
@@ -53,6 +55,7 @@ const main = async (): Promise<void> => {
     covFile: getPathToFile(covFile)!,
     xmlFile: getPathToFile(xmlFile)!,
     covXmlFile: getPathToFile(covXmlFile)!,
+    covJsonFile: getPathToFile(covJsonFile)!,
     defaultBranch: 'main',
     head: 'feat/test',
     base: 'main',
@@ -80,9 +83,14 @@ const main = async (): Promise<void> => {
     },
   };
 
-  const report = options.covXmlFile
-    ? getCoverageXmlReport(options)
-    : getCoverageReport(options);
+  let report;
+  if (options.covJsonFile) {
+    report = getCoverageJsonReport(options);
+  } else if (options.covXmlFile) {
+    report = getCoverageXmlReport(options);
+  } else {
+    report = getCoverageReport(options);
+  }
 
   const html = report ? report.html : '';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import * as core from '@actions/core';
 import * as github from '@actions/github';
 import { getCoverageReport } from './parse';
 import { getCoverageXmlReport } from './parseXml';
+import { getCoverageJsonReport } from './parseJson';
 import { getSummaryReport, getParsedXml, getNotSuccessTest } from './junitXml';
 import { getMultipleReport } from './multiFiles';
 import type { Options, ChangedFiles } from './types';
@@ -225,6 +226,9 @@ const main = async (): Promise<void> => {
   const covXmlFile = core.getInput('pytest-xml-coverage-path', {
     required: false,
   });
+  const covJsonFile = core.getInput('pytest-json-coverage-path', {
+    required: false,
+  });
   const pathPrefix = core.getInput('coverage-path-prefix', { required: false });
   const xmlFile = core.getInput('junitxml-path', { required: false });
   const xmlTitle = core.getInput('junitxml-title', { required: false });
@@ -251,6 +255,7 @@ const main = async (): Promise<void> => {
     pathPrefix,
     covFile,
     covXmlFile,
+    covJsonFile,
     xmlFile,
     title,
     badgeTitle,
@@ -311,9 +316,14 @@ const main = async (): Promise<void> => {
     }
   }
 
-  let report = options.covXmlFile
-    ? getCoverageXmlReport(options)
-    : getCoverageReport(options);
+  let report;
+  if (options.covJsonFile) {
+    report = getCoverageJsonReport(options);
+  } else if (options.covXmlFile) {
+    report = getCoverageXmlReport(options);
+  } else {
+    report = getCoverageReport(options);
+  }
 
   if (!report) {
     report = { html: '', coverage: null, color: 'red' };
@@ -335,9 +345,14 @@ const main = async (): Promise<void> => {
 
   if (html) {
     const newOptions = { ...options, commit: defaultBranch };
-    const output = newOptions.covXmlFile
-      ? getCoverageXmlReport(newOptions)
-      : getCoverageReport(newOptions);
+    let output;
+    if (newOptions.covJsonFile) {
+      output = getCoverageJsonReport(newOptions);
+    } else if (newOptions.covXmlFile) {
+      output = getCoverageXmlReport(newOptions);
+    } else {
+      output = getCoverageReport(newOptions);
+    }
     if (output) {
       core.setOutput('coverageHtml', output.html);
     }
@@ -393,9 +408,13 @@ const main = async (): Promise<void> => {
       warningsArr.push('- Add "remove-links-to-lines: true" to remove line number links');
     }
     core.warning(warningsArr.join('\n'));
-    report = options.covXmlFile
-      ? getCoverageXmlReport({ ...options, hideReport: true })
-      : getCoverageReport({ ...options, hideReport: true });
+    if (options.covJsonFile) {
+      report = getCoverageJsonReport({ ...options, hideReport: true });
+    } else if (options.covXmlFile) {
+      report = getCoverageXmlReport({ ...options, hideReport: true });
+    } else {
+      report = getCoverageReport({ ...options, hideReport: true });
+    }
 
     if (!report) {
       report = { html: '', coverage: null, color: 'red' };

--- a/src/multiFiles.ts
+++ b/src/multiFiles.ts
@@ -1,5 +1,6 @@
 import { getCoverageReport } from './parse';
 import { getCoverageXmlReport } from './parseXml';
+import { getCoverageJsonReport } from './parseJson';
 import { getParsedXml } from './junitXml';
 import * as core from '@actions/core';
 import type { Options, MultipleFileLine } from './types';
@@ -20,15 +21,18 @@ const parseLine = (line: string): MultipleFileLine | null => {
 };
 
 // make internal options
-// covFile and covXmlFile are mutually exclusive — detected by .xml extension
+// covFile, covXmlFile and covJsonFile are mutually exclusive — detected by extension
 const getOptions = (options: Options, line: MultipleFileLine): Options => {
   const isXmlCoverage =
     line.covFile && line.covFile.toLowerCase().endsWith('.xml');
+  const isJsonCoverage =
+    line.covFile && line.covFile.toLowerCase().endsWith('.json');
   return {
     ...options,
     title: line.title,
-    covFile: isXmlCoverage ? '' : line.covFile,
+    covFile: isXmlCoverage || isJsonCoverage ? '' : line.covFile,
     covXmlFile: isXmlCoverage ? line.covFile : '',
+    covJsonFile: isJsonCoverage ? line.covFile : '',
     hideReport: true,
     xmlFile: line.xmlFile,
     xmlTitle: '',
@@ -54,9 +58,14 @@ export const getMultipleReport = (options: Options): string => {
 
     lineReports.forEach((l, i) => {
       const internalOptions = getOptions(options, l);
-      const report = internalOptions.covXmlFile
-        ? getCoverageXmlReport(internalOptions)
-        : getCoverageReport(internalOptions);
+      let report;
+      if (internalOptions.covJsonFile) {
+        report = getCoverageJsonReport(internalOptions);
+      } else if (internalOptions.covXmlFile) {
+        report = getCoverageXmlReport(internalOptions);
+      } else {
+        report = getCoverageReport(internalOptions);
+      }
       const summary = getParsedXml(internalOptions);
 
       if (report && report.html) {
@@ -64,14 +73,17 @@ export const getMultipleReport = (options: Options): string => {
 
         if (i === 0) {
           core.startGroup(
-            internalOptions.covXmlFile || internalOptions.covFile,
+            internalOptions.covXmlFile ||
+              internalOptions.covJsonFile ||
+              internalOptions.covFile,
           );
-          const coverageValue = internalOptions.covXmlFile
-            ? (report.coverage as { cover?: string } | null)?.cover || ''
-            : (report as { coverage: string }).coverage;
+          const coverageValue =
+            internalOptions.covXmlFile || internalOptions.covJsonFile
+              ? (report.coverage as { cover?: string } | null)?.cover || ''
+              : (report as { coverage: string }).coverage;
           core.info(`coverage: ${coverageValue}`);
           core.info(`color: ${report.color}`);
-          if (!internalOptions.covXmlFile) {
+          if (!internalOptions.covXmlFile && !internalOptions.covJsonFile) {
             core.info(
               `warnings: ${(report as { warnings?: number }).warnings}`,
             );
@@ -80,7 +92,7 @@ export const getMultipleReport = (options: Options): string => {
 
           core.setOutput('coverage', coverageValue);
           core.setOutput('color', report.color);
-          if (!internalOptions.covXmlFile) {
+          if (!internalOptions.covXmlFile && !internalOptions.covJsonFile) {
             core.setOutput(
               'warnings',
               (report as { warnings?: number }).warnings,
@@ -88,9 +100,14 @@ export const getMultipleReport = (options: Options): string => {
           }
 
           const newOptions = { ...internalOptions, commit: defaultBranch };
-          const output = newOptions.covXmlFile
-            ? getCoverageXmlReport(newOptions)
-            : getCoverageReport(newOptions);
+          let output;
+          if (newOptions.covJsonFile) {
+            output = getCoverageJsonReport(newOptions);
+          } else if (newOptions.covXmlFile) {
+            output = getCoverageXmlReport(newOptions);
+          } else {
+            output = getCoverageReport(newOptions);
+          }
           if (output) {
             core.setOutput('coverageHtml', output.html);
           }

--- a/src/parseJson.ts
+++ b/src/parseJson.ts
@@ -1,0 +1,205 @@
+import * as core from '@actions/core';
+import { getContent, getCoverageColor } from './utils';
+import { toHtml } from './parse';
+import { formatCoverPercent } from './parseXml';
+import type {
+  Options,
+  CoverageLine,
+  TotalLine,
+  XmlCoverageReport,
+  DataFromXml,
+} from './types';
+
+// coverage.py `coverage json` schema (only the fields we use):
+//   files["path"].summary.{num_statements, missing_lines(count), percent_covered,
+//                          num_branches, missing_branches(count)}
+//   files["path"].missing_lines    -> array of line numbers
+//   files["path"].missing_branches -> array of [from, to] arcs (to < 0 means exit)
+//   totals.{num_statements, missing_lines, percent_covered, num_branches, missing_branches}
+interface JsonSummary {
+  num_statements: number;
+  missing_lines: number;
+  percent_covered: number;
+  num_branches?: number;
+  missing_branches?: number;
+}
+
+interface JsonFile {
+  summary: JsonSummary;
+  missing_lines: number[];
+  missing_branches?: number[][];
+}
+
+interface JsonCoverage {
+  files: Record<string, JsonFile>;
+  totals: JsonSummary;
+}
+
+// read and parse the json coverage file
+const getParsedJson = (options: Options): JsonCoverage | null => {
+  const content = getContent(options.covJsonFile);
+
+  if (!content || !content.length) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(content) as JsonCoverage;
+  } catch (error) {
+    // prettier-ignore
+    core.warning(`Coverage json file is not valid JSON: ${(error as Error).message}`);
+    return null;
+  }
+};
+
+// return true if the parsed json includes the expected structure
+const isValidCoverageContent = (parsedJson: JsonCoverage | null): boolean =>
+  !!parsedJson && !!parsedJson.files && !!parsedJson.totals;
+
+// collapse a sorted list of line numbers into range strings, e.g.
+// [4, 10, 11, 12] -> ["4", "10-12"]
+const collapseRanges = (
+  lineNumbers: number[],
+): { sort: number; text: string }[] =>
+  lineNumbers
+    .slice()
+    .sort((a, b) => a - b)
+    .reduce((arr: number[][], val: number, i: number, a: number[]) => {
+      if (!i || val !== a[i - 1] + 1) arr.push([]);
+      arr[arr.length - 1].push(val);
+      return arr;
+    }, [])
+    .map((range) => ({
+      sort: range[0],
+      text:
+        range.length === 1
+          ? `${range[0]}`
+          : `${range[0]}-${range[range.length - 1]}`,
+    }));
+
+// build the "Missing" column entries the same way `coverage report -m` does:
+// missing statement lines as ranges, plus partial branch arcs as `from->to`
+// (or `from->exit`). An arc whose destination is itself a missing line is
+// omitted, since the line already appears as missing.
+const getMissing = (file: JsonFile): string[] => {
+  const missingLines = file.missing_lines || [];
+  const missingLinesSet = new Set(missingLines);
+
+  const entries = collapseRanges(missingLines);
+
+  (file.missing_branches || []).forEach(([from, to]) => {
+    if (to < 0) {
+      entries.push({ sort: from, text: `${from}->exit` });
+    } else if (!missingLinesSet.has(to)) {
+      entries.push({ sort: from, text: `${from}->${to}` });
+    }
+  });
+
+  return entries.sort((a, b) => a.sort - b.sort).map((e) => e.text);
+};
+
+// convert a single file entry to CoverageLine
+const parseFile = (
+  name: string,
+  file: JsonFile,
+  xmlSkipCovered: boolean,
+): CoverageLine | null => {
+  const { summary } = file;
+  const numBranches = summary.num_branches || 0;
+  const missingBranches = summary.missing_branches || 0;
+  const isFullCoverage = summary.missing_lines === 0 && missingBranches === 0;
+
+  if (xmlSkipCovered && isFullCoverage) {
+    return null;
+  }
+
+  const cover = isFullCoverage
+    ? '100%'
+    : `${formatCoverPercent(summary.percent_covered)}%`;
+
+  const result: CoverageLine = {
+    name,
+    stmts: summary.num_statements.toString(),
+    miss: summary.missing_lines.toString(),
+    cover,
+    missing: getMissing(file),
+  };
+
+  if (numBranches > 0) {
+    result.branch = numBranches.toString();
+    result.brpart = missingBranches.toString();
+  }
+
+  return result;
+};
+
+// convert the top-level totals to a TotalLine
+const getTotalCoverage = (totals: JsonSummary): TotalLine | null => {
+  const cover = formatCoverPercent(totals.percent_covered);
+  const numBranches = totals.num_branches || 0;
+
+  if (!Number.isFinite(cover)) {
+    // prettier-ignore
+    core.warning(`Coverage json file is missing a valid total coverage percentage`);
+    return null;
+  }
+
+  const result: TotalLine = {
+    name: 'TOTAL',
+    stmts: totals.num_statements,
+    miss: totals.missing_lines,
+    cover: cover !== 0 ? `${cover}%` : '0',
+  };
+
+  if (numBranches > 0) {
+    result.branch = numBranches.toString();
+    result.brpart = (totals.missing_branches || 0).toString();
+  }
+
+  return result;
+};
+
+// return summary report in markdown format
+export const getCoverageJsonReport = (
+  options: Options,
+): XmlCoverageReport | null => {
+  try {
+    const parsedJson = getParsedJson(options);
+
+    if (parsedJson && !isValidCoverageContent(parsedJson)) {
+      // prettier-ignore
+      core.error(`Error: coverage file "${options.covJsonFile}" has bad format or wrong data`);
+      return null;
+    }
+
+    const coverage = parsedJson ? getTotalCoverage(parsedJson.totals) : null;
+
+    if (parsedJson && coverage) {
+      const coverageObj: CoverageLine[] = Object.entries(parsedJson.files)
+        .map(([name, file]) => parseFile(name, file, options.xmlSkipCovered))
+        .filter((line): line is CoverageLine => line !== null);
+      const dataFromXml: DataFromXml = {
+        coverage: coverageObj,
+        total: coverage,
+      };
+      const html = toHtml(null, options, dataFromXml);
+      const color = getCoverageColor(coverage.cover);
+
+      return { html, coverage, color };
+    }
+
+    return null;
+  } catch (error) {
+    // prettier-ignore
+    core.error(`Error generating coverage report from "${options.covJsonFile}". ${(error as Error).message}`);
+  }
+
+  return null;
+};
+
+export const exportedForTesting = {
+  isValidCoverageContent,
+  collapseRanges,
+  getMissing,
+  getTotalCoverage,
+};

--- a/src/parseXml.ts
+++ b/src/parseXml.ts
@@ -47,7 +47,7 @@ const computeCoverPercent = (
 };
 
 // round like `coverage report`, but never round up to 100 or down to 0
-const formatCoverPercent = (percent: number): number => {
+export const formatCoverPercent = (percent: number): number => {
   if (!Number.isFinite(percent)) {
     return NaN;
   }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -5,6 +5,7 @@ export interface Options {
   pathPrefix: string;
   covFile: string;
   covXmlFile: string;
+  covJsonFile: string;
   xmlFile: string;
   title: string;
   badgeTitle: string;


### PR DESCRIPTION
## **User description**
Closes #282.

Adds a third coverage input format alongside TXT and XML: the JSON report from `coverage json`, via a new `pytest-json-coverage-path` input.

- New `src/parseJson.ts` mirrors the XML parser and reuses the existing `toHtml`/`DataFromXml` rendering pipeline (badge, folder-grouped table, colors).
- Supports branch coverage, missing-line ranges, and partial-branch arrows (`line->target`, `line->exit`). The Missing column matches `coverage report -m` (an arc whose destination is an already-missing line is omitted).
- Uses coverage.py's `percent_covered`; reuses `formatCoverPercent` with a finite-percentage guard.
- Honors `xml-skip-covered`; supports monorepo `multiple-files` (`.json` detection).
- Precedence: JSON > XML > TXT. TXT/XML behavior unchanged.
- Tests + fixtures added; README + `action.yml` documented; `dist` rebuilt.

Validated end-to-end in `api-testing-example`: the full matrix (all existing TXT/XML/feature cases + new JSON cases) passes with no regressions, and comments update in place on re-run. Supersedes the auto-generated #283.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds first-class support for coverage.py JSON reports via a new `pytest-json-coverage-path` input, with JSON now preferred over XML/TXT. Released as v1.10.0; output (HTML, badges, colors) matches existing reports.

- New Features
  - Added `pytest-json-coverage-path` for `coverage json`; precedence is JSON > XML > TXT.
  - Reuses existing HTML pipeline; supports branch details and missing arcs (`line->target`, `line->exit`), omitting arcs to already-missing lines.
  - Honors `xml-skip-covered`; monorepo `multiple-files` now detects `.json`.
  - Exported `formatCoverPercent`; JSON uses coverage.py `percent_covered` with a finite guard.
  - Docs (`README.md`, `action.yml`), tests/fixtures, `dist`, and `CHANGELOG.md` updated; version bumped to 1.10.0.

- Migration
  - Generate JSON with `coverage json -o coverage.json`, then set `pytest-json-coverage-path`.
  - If multiple inputs are provided, JSON takes precedence; TXT/XML behavior is unchanged.

<sup>Written for commit eeb248be0a1da051a1fec9bf239e9e065320603b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MishaKav/pytest-coverage-comment/pull/286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Add support for coverage.json reports**

### What Changed
- You can now use a JSON coverage report from `coverage json` as the coverage source
- JSON reports take priority over XML and text reports when more than one input is provided
- Monorepo reports now recognize `.json` files and use the same comment and badge output as the existing coverage formats
- The new JSON report format is documented in the action inputs and README, with tests added for statement-only and branch coverage cases

### Impact
`✅ Use coverage.json without converting to XML`
`✅ Fewer setup steps for Python coverage comments`
`✅ Consistent coverage comments in monorepos`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
