### PR TITLE
Fix badge creation on Dependabot and fork PRs [skip ci]

### DIFF
--- a/.github/workflows/live-test.yml
+++ b/.github/workflows/live-test.yml
@@ -38,9 +38,13 @@ jobs:
           echo "Not Success Test Info - ${{ steps.coverageComment.outputs.notSuccessTestInfo }}"
 
       - name: Create the Badge
+        # skipped on Dependabot and fork pull requests, which get no secrets
+        if: env.BADGE_AUTH != ''
+        env:
+          BADGE_AUTH: ${{ secrets.PYTEST_COVERAGE_COMMENT }}
         uses: schneegans/dynamic-badges-action@v1.9.0
         with:
-          auth: ${{ secrets.PYTEST_COVERAGE_COMMENT }}
+          auth: ${{ env.BADGE_AUTH }}
           gistID: 5e90d640f8c212ab7bbac38f72323f80
           filename: pytest-coverage-comment__main.json
           label: Coverage Report


### PR DESCRIPTION
## What does this PR do?

Fixes the badge creation step to gracefully skip on Dependabot and fork pull requests, which don't have access to repository secrets. The change moves the `PYTEST_COVERAGE_COMMENT` secret into an environment variable with a conditional check, so the step is skipped when the secret is unavailable rather than failing.

## Related Issue

Closes #

## Technical Details

- Added `if: env.BADGE_AUTH != ''` condition to skip the badge creation step when secrets are unavailable
- Moved `secrets.PYTEST_COVERAGE_COMMENT` to an environment variable `BADGE_AUTH` so it can be checked before use
- Updated the `auth` input to reference the environment variable instead of the secret directly

This prevents workflow failures on Dependabot PRs and forks while maintaining badge functionality on regular PRs with secret access.

## Checklist

- [x] Tested locally
- [ ] Ran `npm run all`
- [ ] Updated docs (if needed)

https://claude.ai/code/session_01RndLkx38kB7kunVmbDY1WE

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skips coverage badge publishing when the gist token is unavailable on Dependabot and fork PRs. Previously the badge step failed with “Missing auth secret”; now it is skipped, while trusted runs still update the badge.

- Adds condition `if: env.BADGE_AUTH != ''` to the badge step in live-test.yml.
- Exposes `secrets.PYTEST_COVERAGE_COMMENT` as `BADGE_AUTH` and passes it as `auth` to `schneegans/dynamic-badges-action@v1.9.0`.

<sup>Written for commit 93f8681ff9413d4d104c4e85badb84d204470cd5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MishaKav/pytest-coverage-comment/pull/295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

