### PR TITLE
fix: improve output when reportOnlyChangedFiles is enabled

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -40220,7 +40220,7 @@ const toTable = (data, options, dataFromXml = null) => {
     ], []);
     const hasLines = rows.length > 0;
     const isFilesChanged = reportOnlyChangedFiles && !hasLines
-        ? `<i>report-only-changed-files is enabled. No files were changed during this commit :)</i>`
+        ? `<i>report-only-changed-files is enabled. No changed files were found in the coverage report :)</i>`
         : '';
     // prettier-ignore
     return `<table>${headTr}<tbody>${rows.join('')}${totalTr}</tbody></table>${isFilesChanged}`;

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -337,7 +337,7 @@ const toTable = (
   const hasLines = rows.length > 0;
   const isFilesChanged =
     reportOnlyChangedFiles && !hasLines
-      ? `<i>report-only-changed-files is enabled. No files were changed during this commit :)</i>`
+      ? `<i>report-only-changed-files is enabled. No changed files were found in the coverage report :)</i>`
       : '';
 
   // prettier-ignore


### PR DESCRIPTION
## What does this PR do?

When `reportOnlyChangedFiles` is enabled and there are no reports for the changed files the comment can be misleading (unless the coverage is 100%).

For example:

<img width="557" height="175" alt="image" src="https://github.com/user-attachments/assets/859d3f93-f495-43bc-ae0b-e8d0847e914b" />

I propose to make this message more clear.

## Related Issue

Closes #

## Checklist

- [ ] Tested locally
- [ ] Ran `npm run all`
- [ ] Updated docs (if needed)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the coverage comment when `reportOnlyChangedFiles` is enabled. Previously, if no rows were reported, the comment said “No files were changed during this commit,” which implied no changes; it now says “No files with missing coverage were changed during this commit,” accurately reflecting fully covered changes.

No impact on coverage calculations, thresholds, or status checks; only the message text changes.

<sup>Written for commit bab7b70a01f31a00f05e51a2adb3e2bc25b375eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MishaKav/pytest-coverage-comment/pull/296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

