### PR TITLE
Improve message when no changed files found in coverage report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog of the Pytest Coverage Comment
 
+## [Pytest Coverage Comment 1.11.2](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.11.2)
+
+**Release Date:** 2026-08-26
+
+#### Changes
+
+- improve the comment message when `report-only-changed-files` is enabled and none of the changed files appear in the coverage report — it now says _"No changed files were found in the coverage report"_ instead of the misleading _"No files were changed during this commit"_ (#296), thanks to [@mschoettle](https://github.com/mschoettle) for contribution
+
 ## [Pytest Coverage Comment 1.11.1](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.11.1)
 
 **Release Date:** 2026-08-22

--- a/dist/index.js
+++ b/dist/index.js
@@ -40220,7 +40220,7 @@ const toTable = (data, options, dataFromXml = null) => {
     ], []);
     const hasLines = rows.length > 0;
     const isFilesChanged = reportOnlyChangedFiles && !hasLines
-        ? `<i>report-only-changed-files is enabled. No files were changed during this commit :)</i>`
+        ? `<i>report-only-changed-files is enabled. No changed files were found in the coverage report :)</i>`
         : '';
     // prettier-ignore
     return `<table>${headTr}<tbody>${rows.join('')}${totalTr}</tbody></table>${isFilesChanged}`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pytest-coverage-comment",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pytest-coverage-comment",
-      "version": "1.11.1",
+      "version": "1.11.2",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pytest-coverage-comment",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "Comments a pull request with the pytest code coverage badge, full report and tests summary",
   "author": "Misha Kav",
   "license": "MIT",

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -337,7 +337,7 @@ const toTable = (
   const hasLines = rows.length > 0;
   const isFilesChanged =
     reportOnlyChangedFiles && !hasLines
-      ? `<i>report-only-changed-files is enabled. No files were changed during this commit :)</i>`
+      ? `<i>report-only-changed-files is enabled. No changed files were found in the coverage report :)</i>`
       : '';
 
   // prettier-ignore


### PR DESCRIPTION
## What does this PR do?

Improves the comment message displayed when `report-only-changed-files` is enabled and none of the changed files appear in the coverage report. The message now says _"No changed files were found in the coverage report"_ instead of the misleading _"No files were changed during this commit"_.

This clarifies that the issue is with the coverage report contents, not with the commit itself.

## Related Issue

Closes #296

## Changes

- Updated message in `src/parse.ts` (source)
- Updated corresponding message in `dist/index.js` (compiled output)
- Bumped version to 1.11.2 in `package.json`
- Added changelog entry

## Checklist

- [x] Tested locally
- [x] Ran `npm run all`
- [x] Updated docs (changelog)

https://claude.ai/code/session_01Tee66jSRG3QF2tsAvkeCrh