### PR TITLE
feat: show warning in coverage comment when coverage report too long

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -14,7 +14,7 @@ vi.mock('@actions/github', () => ({
   getOctokit: vi.fn(),
 }));
 
-import { truncateSummary } from '../src/index';
+import { tooLongNotice, truncateSummary } from '../src/index';
 
 describe('truncateSummary', () => {
   test('should return content as-is when under limit', () => {
@@ -40,5 +40,31 @@ describe('truncateSummary', () => {
   test('should handle exact limit', () => {
     const content = 'Exact';
     expect(truncateSummary(content, 5)).toBe('Exact');
+  });
+});
+
+describe('tooLongNotice', () => {
+  test('should mention the maximum length', () => {
+    const result = tooLongNotice(65536, null);
+    expect(result).toContain('> [!WARNING]');
+    // prettier-ignore
+    expect(result).toContain('too long (maximum is 65536 characters)');
+  });
+
+  test('should link to the job log when a run url is given', () => {
+    const runUrl = 'https://github.com/owner/test/actions/runs/42';
+    const result = tooLongNotice(65536, runUrl);
+    expect(result).toContain(`[job log](${runUrl})`);
+  });
+
+  test('should omit the link when no run url is given', () => {
+    const result = tooLongNotice(65536, null);
+    expect(result).not.toContain('job log');
+    expect(result).not.toContain('](');
+  });
+
+  test('should keep every line inside the blockquote', () => {
+    const result = tooLongNotice(65536, 'https://example.com/run');
+    expect(result.split('\n').every((line) => line.startsWith('>'))).toBe(true);
   });
 });

--- a/dist/index.js
+++ b/dist/index.js
@@ -38731,7 +38731,7 @@ var __importStar = (this && this.__importStar) || (function () {
     };
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.truncateSummary = exports.resolveCommitSha = void 0;
+exports.tooLongNotice = exports.truncateSummary = exports.resolveCommitSha = void 0;
 const core = __importStar(__nccwpck_require__(7484));
 const github = __importStar(__nccwpck_require__(3228));
 const parse_1 = __nccwpck_require__(2828);
@@ -38802,6 +38802,17 @@ const truncateSummary = (content, maxLength) => {
     return truncatedContent + truncationMessage;
 };
 exports.truncateSummary = truncateSummary;
+// short notice shown in the comment in place of the dropped coverage report,
+// the full list of suggestions stays in the job log
+const tooLongNotice = (maxLength, runUrl) => {
+    // prettier-ignore
+    const reason = `Your comment is too long (maximum is ${maxLength} characters), so the coverage report was not added.`;
+    const details = runUrl
+        ? ` See the [job log](${runUrl}) for how to reduce it.`
+        : '';
+    return `> [!WARNING]\n> ${reason}${details}`;
+};
+exports.tooLongNotice = tooLongNotice;
 const handlePermissionError = (
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 error, context) => {
@@ -39052,10 +39063,12 @@ const main = async () => {
         multipleFilesHtml = `\n\n${(0, multiFiles_1.getMultipleReport)(options, failedTestsBudget)}`;
     }
     // every part that ends up in the comment body counts toward the limit
+    let tooLongHtml = '';
     const commentLength = () => html.length +
         summaryReport.length +
         failedTestsHtml.length +
-        multipleFilesHtml.length;
+        multipleFilesHtml.length +
+        tooLongHtml.length;
     const multiFailedTestsShown = options.showFailedTests && multipleFilesHtml.includes('Failed Tests');
     if (!options.hideReport &&
         commentLength() > MAX_COMMENT_LENGTH &&
@@ -39084,6 +39097,11 @@ const main = async () => {
             warningsArr.push('- Reduce "max-failed-tests" to show fewer failed tests in report');
         }
         core.warning(warningsArr.join('\n'));
+        // surface the reason in the comment too, the report is silently gone otherwise
+        const runUrl = context.runId
+            ? `${options.repoUrl}/actions/runs/${context.runId}`
+            : null;
+        tooLongHtml = (0, exports.tooLongNotice)(MAX_COMMENT_LENGTH, runUrl);
         if (options.covJsonFile) {
             report = (0, parseJson_1.getCoverageJsonReport)({ ...options, hideReport: true });
         }
@@ -39108,6 +39126,9 @@ const main = async () => {
         }
     }
     finalHtml += html;
+    if (tooLongHtml) {
+        finalHtml += finalHtml.length ? `\n\n${tooLongHtml}` : tooLongHtml;
+    }
     finalHtml += finalHtml.length ? `\n\n${summaryReport}` : summaryReport;
     finalHtml += failedTestsHtml ? `\n\n${failedTestsHtml}` : '';
     finalHtml += multipleFilesHtml

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,21 @@ export const truncateSummary = (content: string, maxLength: number): string => {
   return truncatedContent + truncationMessage;
 };
 
+// short notice shown in the comment in place of the dropped coverage report,
+// the full list of suggestions stays in the job log
+export const tooLongNotice = (
+  maxLength: number,
+  runUrl: string | null,
+): string => {
+  // prettier-ignore
+  const reason = `Your comment is too long (maximum is ${maxLength} characters), so the coverage report was not added.`;
+  const details = runUrl
+    ? ` See the [job log](${runUrl}) for how to reduce it.`
+    : '';
+
+  return `> [!WARNING]\n> ${reason}${details}`;
+};
+
 const handlePermissionError = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   error: any,
@@ -419,11 +434,13 @@ const main = async (): Promise<void> => {
   }
 
   // every part that ends up in the comment body counts toward the limit
+  let tooLongHtml = '';
   const commentLength = (): number =>
     html.length +
     summaryReport.length +
     failedTestsHtml.length +
-    multipleFilesHtml.length;
+    multipleFilesHtml.length +
+    tooLongHtml.length;
   const multiFailedTestsShown =
     options.showFailedTests && multipleFilesHtml.includes('Failed Tests');
 
@@ -459,6 +476,13 @@ const main = async (): Promise<void> => {
       warningsArr.push('- Reduce "max-failed-tests" to show fewer failed tests in report');
     }
     core.warning(warningsArr.join('\n'));
+
+    // surface the reason in the comment too, the report is silently gone otherwise
+    const runUrl = context.runId
+      ? `${options.repoUrl}/actions/runs/${context.runId}`
+      : null;
+    tooLongHtml = tooLongNotice(MAX_COMMENT_LENGTH, runUrl);
+
     if (options.covJsonFile) {
       report = getCoverageJsonReport({ ...options, hideReport: true });
     } else if (options.covXmlFile) {
@@ -485,6 +509,9 @@ const main = async (): Promise<void> => {
   }
 
   finalHtml += html;
+  if (tooLongHtml) {
+    finalHtml += finalHtml.length ? `\n\n${tooLongHtml}` : tooLongHtml;
+  }
   finalHtml += finalHtml.length ? `\n\n${summaryReport}` : summaryReport;
   finalHtml += failedTestsHtml ? `\n\n${failedTestsHtml}` : '';
   finalHtml += multipleFilesHtml


### PR DESCRIPTION
## What does this PR do?

When the coverage comment is too long and gets truncated it is only visible in the job log. This PR adds a warning to the comment itself to show that it was truncated as it can otherwise go unnoticed.

## Related Issue

Closes #

## Checklist

- [x] Tested locally
- [x] Ran `npm run all`
- [ ] Updated docs (if needed)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a warning to the coverage comment when it's too long and gets truncated, instead of only logging the truncation to the job log.

- New `tooLongNotice` displays a warning in the comment when the coverage report is dropped.
- Links to the job log when a run ID is available.
- Adds unit tests covering the notice text, link behavior, and blockquote formatting.

<sup>Written for commit 516234d4c8b068c7ebdb555ff7afee3754ca8239. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MishaKav/pytest-coverage-comment/pull/298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

