### PR TITLE
feat: show warning in comment when coverage report is too long (v1.12.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog of the Pytest Coverage Comment
 
+## [Pytest Coverage Comment 1.12.0](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.12.0)
+
+**Release Date:** 2026-08-30
+
+#### Changes
+
+- show a warning inside the comment itself when it's too long (over 65,536 characters) and the detailed coverage report gets dropped — previously the report silently disappeared and the reason was only visible in the job log. The warning links to the job log, which lists the ways to reduce the comment size (#298), thanks to [@mschoettle](https://github.com/mschoettle) for contribution
+
 ## [Pytest Coverage Comment 1.11.2](https://github.com/MishaKav/pytest-coverage-comment/tree/v1.11.2)
 
 **Release Date:** 2026-08-26

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -14,7 +14,7 @@ vi.mock('@actions/github', () => ({
   getOctokit: vi.fn(),
 }));
 
-import { truncateSummary } from '../src/index';
+import { tooLongNotice, truncateSummary } from '../src/index';
 
 describe('truncateSummary', () => {
   test('should return content as-is when under limit', () => {
@@ -40,5 +40,31 @@ describe('truncateSummary', () => {
   test('should handle exact limit', () => {
     const content = 'Exact';
     expect(truncateSummary(content, 5)).toBe('Exact');
+  });
+});
+
+describe('tooLongNotice', () => {
+  test('should mention the maximum length', () => {
+    const result = tooLongNotice(65536, null);
+    expect(result).toContain('> [!WARNING]');
+    // prettier-ignore
+    expect(result).toContain('too long (maximum is 65536 characters)');
+  });
+
+  test('should link to the job log when a run url is given', () => {
+    const runUrl = 'https://github.com/owner/test/actions/runs/42';
+    const result = tooLongNotice(65536, runUrl);
+    expect(result).toContain(`[job log](${runUrl})`);
+  });
+
+  test('should omit the link when no run url is given', () => {
+    const result = tooLongNotice(65536, null);
+    expect(result).not.toContain('job log');
+    expect(result).not.toContain('](');
+  });
+
+  test('should keep every line inside the blockquote', () => {
+    const result = tooLongNotice(65536, 'https://example.com/run');
+    expect(result.split('\n').every((line) => line.startsWith('>'))).toBe(true);
   });
 });

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -45,7 +45,7 @@ describe('truncateSummary', () => {
 
 describe('tooLongNotice', () => {
   test('should mention the maximum length', () => {
-    const result = tooLongNotice(65536, null);
+    const result = tooLongNotice(null);
     expect(result).toContain('> [!WARNING]');
     // prettier-ignore
     expect(result).toContain('too long (maximum is 65536 characters)');
@@ -53,18 +53,18 @@ describe('tooLongNotice', () => {
 
   test('should link to the job log when a run url is given', () => {
     const runUrl = 'https://github.com/owner/test/actions/runs/42';
-    const result = tooLongNotice(65536, runUrl);
+    const result = tooLongNotice(runUrl);
     expect(result).toContain(`[job log](${runUrl})`);
   });
 
   test('should omit the link when no run url is given', () => {
-    const result = tooLongNotice(65536, null);
+    const result = tooLongNotice(null);
     expect(result).not.toContain('job log');
     expect(result).not.toContain('](');
   });
 
   test('should keep every line inside the blockquote', () => {
-    const result = tooLongNotice(65536, 'https://example.com/run');
+    const result = tooLongNotice('https://example.com/run');
     expect(result.split('\n').every((line) => line.startsWith('>'))).toBe(true);
   });
 });

--- a/dist/index.js
+++ b/dist/index.js
@@ -38731,7 +38731,7 @@ var __importStar = (this && this.__importStar) || (function () {
     };
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.truncateSummary = exports.resolveCommitSha = void 0;
+exports.tooLongNotice = exports.truncateSummary = exports.resolveCommitSha = void 0;
 const core = __importStar(__nccwpck_require__(7484));
 const github = __importStar(__nccwpck_require__(3228));
 const parse_1 = __nccwpck_require__(2828);
@@ -38802,6 +38802,17 @@ const truncateSummary = (content, maxLength) => {
     return truncatedContent + truncationMessage;
 };
 exports.truncateSummary = truncateSummary;
+// short notice shown in the comment in place of the dropped coverage report,
+// the full list of suggestions stays in the job log
+const tooLongNotice = (maxLength, runUrl) => {
+    // prettier-ignore
+    const reason = `Your comment is too long (maximum is ${maxLength} characters), so the coverage report was not added.`;
+    const details = runUrl
+        ? ` See the [job log](${runUrl}) for how to reduce it.`
+        : '';
+    return `> [!WARNING]\n> ${reason}${details}`;
+};
+exports.tooLongNotice = tooLongNotice;
 const handlePermissionError = (
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 error, context) => {
@@ -39052,10 +39063,12 @@ const main = async () => {
         multipleFilesHtml = `\n\n${(0, multiFiles_1.getMultipleReport)(options, failedTestsBudget)}`;
     }
     // every part that ends up in the comment body counts toward the limit
+    let tooLongHtml = '';
     const commentLength = () => html.length +
         summaryReport.length +
         failedTestsHtml.length +
-        multipleFilesHtml.length;
+        multipleFilesHtml.length +
+        tooLongHtml.length;
     const multiFailedTestsShown = options.showFailedTests && multipleFilesHtml.includes('Failed Tests');
     if (!options.hideReport &&
         commentLength() > MAX_COMMENT_LENGTH &&
@@ -39084,6 +39097,11 @@ const main = async () => {
             warningsArr.push('- Reduce "max-failed-tests" to show fewer failed tests in report');
         }
         core.warning(warningsArr.join('\n'));
+        // surface the reason in the comment too, the report is silently gone otherwise
+        const runUrl = context.runId
+            ? `${options.repoUrl}/actions/runs/${context.runId}`
+            : null;
+        tooLongHtml = (0, exports.tooLongNotice)(MAX_COMMENT_LENGTH, runUrl);
         if (options.covJsonFile) {
             report = (0, parseJson_1.getCoverageJsonReport)({ ...options, hideReport: true });
         }
@@ -39108,6 +39126,9 @@ const main = async () => {
         }
     }
     finalHtml += html;
+    if (tooLongHtml) {
+        finalHtml += finalHtml.length ? `\n\n${tooLongHtml}` : tooLongHtml;
+    }
     finalHtml += finalHtml.length ? `\n\n${summaryReport}` : summaryReport;
     finalHtml += failedTestsHtml ? `\n\n${failedTestsHtml}` : '';
     finalHtml += multipleFilesHtml

--- a/dist/index.js
+++ b/dist/index.js
@@ -38804,9 +38804,9 @@ const truncateSummary = (content, maxLength) => {
 exports.truncateSummary = truncateSummary;
 // short notice shown in the comment in place of the dropped coverage report,
 // the full list of suggestions stays in the job log
-const tooLongNotice = (maxLength, runUrl) => {
+const tooLongNotice = (runUrl) => {
     // prettier-ignore
-    const reason = `Your comment is too long (maximum is ${maxLength} characters), so the coverage report was not added.`;
+    const reason = `Your comment is too long (maximum is ${MAX_COMMENT_LENGTH} characters), so the coverage report was not added.`;
     const details = runUrl
         ? ` See the [job log](${runUrl}) for how to reduce it.`
         : '';
@@ -39101,7 +39101,7 @@ const main = async () => {
         const runUrl = context.runId
             ? `${options.repoUrl}/actions/runs/${context.runId}`
             : null;
-        tooLongHtml = (0, exports.tooLongNotice)(MAX_COMMENT_LENGTH, runUrl);
+        tooLongHtml = (0, exports.tooLongNotice)(runUrl);
         if (options.covJsonFile) {
             report = (0, parseJson_1.getCoverageJsonReport)({ ...options, hideReport: true });
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pytest-coverage-comment",
-  "version": "1.11.2",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pytest-coverage-comment",
-      "version": "1.11.2",
+      "version": "1.12.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pytest-coverage-comment",
-  "version": "1.11.2",
+  "version": "1.12.0",
   "description": "Comments a pull request with the pytest code coverage badge, full report and tests summary",
   "author": "Misha Kav",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,12 +92,9 @@ export const truncateSummary = (content: string, maxLength: number): string => {
 
 // short notice shown in the comment in place of the dropped coverage report,
 // the full list of suggestions stays in the job log
-export const tooLongNotice = (
-  maxLength: number,
-  runUrl: string | null,
-): string => {
+export const tooLongNotice = (runUrl: string | null): string => {
   // prettier-ignore
-  const reason = `Your comment is too long (maximum is ${maxLength} characters), so the coverage report was not added.`;
+  const reason = `Your comment is too long (maximum is ${MAX_COMMENT_LENGTH} characters), so the coverage report was not added.`;
   const details = runUrl
     ? ` See the [job log](${runUrl}) for how to reduce it.`
     : '';
@@ -481,7 +478,7 @@ const main = async (): Promise<void> => {
     const runUrl = context.runId
       ? `${options.repoUrl}/actions/runs/${context.runId}`
       : null;
-    tooLongHtml = tooLongNotice(MAX_COMMENT_LENGTH, runUrl);
+    tooLongHtml = tooLongNotice(runUrl);
 
     if (options.covJsonFile) {
       report = getCoverageJsonReport({ ...options, hideReport: true });

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,21 @@ export const truncateSummary = (content: string, maxLength: number): string => {
   return truncatedContent + truncationMessage;
 };
 
+// short notice shown in the comment in place of the dropped coverage report,
+// the full list of suggestions stays in the job log
+export const tooLongNotice = (
+  maxLength: number,
+  runUrl: string | null,
+): string => {
+  // prettier-ignore
+  const reason = `Your comment is too long (maximum is ${maxLength} characters), so the coverage report was not added.`;
+  const details = runUrl
+    ? ` See the [job log](${runUrl}) for how to reduce it.`
+    : '';
+
+  return `> [!WARNING]\n> ${reason}${details}`;
+};
+
 const handlePermissionError = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   error: any,
@@ -419,11 +434,13 @@ const main = async (): Promise<void> => {
   }
 
   // every part that ends up in the comment body counts toward the limit
+  let tooLongHtml = '';
   const commentLength = (): number =>
     html.length +
     summaryReport.length +
     failedTestsHtml.length +
-    multipleFilesHtml.length;
+    multipleFilesHtml.length +
+    tooLongHtml.length;
   const multiFailedTestsShown =
     options.showFailedTests && multipleFilesHtml.includes('Failed Tests');
 
@@ -459,6 +476,13 @@ const main = async (): Promise<void> => {
       warningsArr.push('- Reduce "max-failed-tests" to show fewer failed tests in report');
     }
     core.warning(warningsArr.join('\n'));
+
+    // surface the reason in the comment too, the report is silently gone otherwise
+    const runUrl = context.runId
+      ? `${options.repoUrl}/actions/runs/${context.runId}`
+      : null;
+    tooLongHtml = tooLongNotice(MAX_COMMENT_LENGTH, runUrl);
+
     if (options.covJsonFile) {
       report = getCoverageJsonReport({ ...options, hideReport: true });
     } else if (options.covXmlFile) {
@@ -485,6 +509,9 @@ const main = async (): Promise<void> => {
   }
 
   finalHtml += html;
+  if (tooLongHtml) {
+    finalHtml += finalHtml.length ? `\n\n${tooLongHtml}` : tooLongHtml;
+  }
   finalHtml += finalHtml.length ? `\n\n${summaryReport}` : summaryReport;
   finalHtml += failedTestsHtml ? `\n\n${failedTestsHtml}` : '';
   finalHtml += multipleFilesHtml


### PR DESCRIPTION
## What does this PR do?

Brings the truncation warning feature from #298 (by @mschoettle) into `main`, together with release preparation:

- when the comment exceeds GitHub's 65,536-character limit and the detailed coverage report is dropped, a `> [!WARNING]` notice now appears in the comment itself, linking to the job log with the reduction tips — previously the report silently disappeared
- refactor: `tooLongNotice` now reads `MAX_COMMENT_LENGTH` directly instead of receiving it as a parameter (it's a module-level constant in the same file)
- chore: bump version to 1.12.0 and add the CHANGELOG entry

The missing final size enforcement discussed in #298 is intentionally out of scope and tracked in #299.

## Related Issue

Closes #

## Checklist

- [x] Tested locally
- [x] Ran `npm run all`
- [ ] Updated docs (if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JpeeSEUqmiQrNJA283Njoq

---
_Generated by [Claude Code](https://claude.ai/code/session_01JpeeSEUqmiQrNJA283Njoq)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows a warning in the comment when it exceeds GitHub's 65,536-character limit and the detailed coverage report is dropped, instead of silently disappearing. The `> [!WARNING]` notice links to the job log, which lists ways to reduce comment size.

- Refactors `tooLongNotice` to read `MAX_COMMENT_LENGTH` directly instead of receiving it as a parameter.
- Bumps version to `1.12.0` and adds a CHANGELOG entry.

<sup>Written for commit a199849084f0a95a145c212da6f31b03d7ff3c75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MishaKav/pytest-coverage-comment/pull/300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

